### PR TITLE
fix(CLNP-630): duplicated messages

### DIFF
--- a/packages/uikit-chat-hooks/src/channel/useChannelMessagesReducer.ts
+++ b/packages/uikit-chat-hooks/src/channel/useChannelMessagesReducer.ts
@@ -3,7 +3,15 @@ import { useReducer } from 'react';
 import { SendableMessage } from '@sendbird/chat/lib/__definition';
 import { SendingStatus } from '@sendbird/chat/message';
 import type { SendbirdBaseMessage } from '@sendbird/uikit-utils';
-import { SendbirdMessage, arrayToMapWithGetter, isMyMessage, isNewMessage, useIIFE } from '@sendbird/uikit-utils';
+import {
+  SendbirdMessage,
+  arrayToMapWithGetter,
+  getMessageUniqId,
+  isMyMessage,
+  isNewMessage,
+  isSendableMessage,
+  useIIFE,
+} from '@sendbird/uikit-utils';
 
 type Options = {
   sortComparator?: (a: SendbirdMessage, b: SendbirdMessage) => number;
@@ -44,24 +52,27 @@ const defaultReducer = ({ ...draft }: State, action: Action) => {
       const userId = action.value.currentUserId;
 
       if (action.value.clearBeforeAction) {
-        draft['messageMap'] = arrayToMapWithGetter(action.value.messages, (it) => getMessageId(it, userId));
+        draft['messageMap'] = messagesToObject(action.value.messages);
       } else {
         // Filtering meaningless message updates
         const nextMessages = action.value.messages.filter((next) => {
           if (isMyMessage(next, userId)) {
-            const prev = draft['messageMap'][getMessageId(next, userId)];
-            if (isMyMessage(prev, userId)) return shouldUpdateMessage(prev, next);
+            const prev = draft['messageMap'][next.reqId] || draft['messageMap'][next.messageId];
+            if (isMyMessage(prev, userId)) {
+              const shouldUpdate = shouldUpdateMessage(prev, next);
+              if (shouldUpdate) {
+                // Remove existing messages before update to prevent duplicate display
+                delete draft['messageMap'][prev.reqId];
+                delete draft['messageMap'][prev.messageId];
+              }
+              return shouldUpdate;
+            }
           }
           return true;
         });
 
-        // Remove existing messages before update for prevent duplicate display
-        nextMessages.map((it) => getMessageId(it, userId)).forEach((key) => delete draft['messageMap'][key]);
-
-        draft['messageMap'] = {
-          ...draft['messageMap'],
-          ...arrayToMapWithGetter(nextMessages, (it) => getMessageId(it, userId)),
-        };
+        const obj = messagesToObject(nextMessages);
+        draft['messageMap'] = { ...draft['messageMap'], ...obj };
       }
 
       return draft;
@@ -71,15 +82,15 @@ const defaultReducer = ({ ...draft }: State, action: Action) => {
       const newMessages = action.value.messages.filter((it) => isNewMessage(it, userId));
 
       if (action.value.clearBeforeAction) {
-        draft['newMessageMap'] = arrayToMapWithGetter(newMessages, (it) => getMessageId(it, userId));
+        draft['newMessageMap'] = arrayToMapWithGetter(newMessages, getMessageUniqId);
       } else {
-        // Remove existing messages before update for prevent duplicate display
+        // Remove existing messages before update to prevent duplicate display
         const messageKeys = newMessages.map((it) => it.messageId);
         messageKeys.forEach((key) => delete draft['newMessageMap'][key]);
 
         draft['newMessageMap'] = {
           ...draft['newMessageMap'],
-          ...arrayToMapWithGetter(newMessages, (it) => getMessageId(it, userId)),
+          ...arrayToMapWithGetter(newMessages, getMessageUniqId),
         };
       }
 
@@ -89,12 +100,38 @@ const defaultReducer = ({ ...draft }: State, action: Action) => {
     case 'delete_new_messages': {
       const key = action.type === 'delete_messages' ? 'messageMap' : 'newMessageMap';
       draft[key] = { ...draft[key] };
-      action.value.messageIds.forEach((msgId) => delete draft[key][msgId]);
-      action.value.reqIds.forEach((reqId) => delete draft[key][reqId]);
+      action.value.messageIds.forEach((msgId) => {
+        const message = draft[key][msgId];
+        if (message) {
+          if (isSendableMessage(message)) delete draft[key][message.reqId];
+          delete draft[key][message.messageId];
+        }
+      });
+      action.value.reqIds.forEach((reqId) => {
+        const message = draft[key][reqId];
+        if (message) {
+          if (isSendableMessage(message)) delete draft[key][message.reqId];
+          delete draft[key][message.messageId];
+        }
+      });
 
       return draft;
     }
   }
+};
+
+const messagesToObject = (messages: SendbirdBaseMessage[]) => {
+  return messages.reduce((accum, curr) => {
+    if (isSendableMessage(curr)) {
+      accum[curr.reqId] = curr;
+      if (curr.sendingStatus === SendingStatus.SUCCEEDED) {
+        accum[curr.messageId] = curr;
+      }
+    } else {
+      accum[curr.messageId] = curr;
+    }
+    return accum;
+  }, {} as Record<string, SendbirdBaseMessage>);
 };
 
 const shouldUpdateMessage = (prev: SendableMessage, next: SendableMessage) => {
@@ -103,13 +140,6 @@ const shouldUpdateMessage = (prev: SendableMessage, next: SendableMessage) => {
 
   // message sending status update
   return prev.sendingStatus !== next.sendingStatus;
-};
-
-const getMessageId = (message: SendbirdBaseMessage, userId?: string) => {
-  if (isMyMessage(message, userId) && message.reqId) {
-    return message.reqId;
-  }
-  return String(message.messageId);
 };
 
 export const useChannelMessagesReducer = (sortComparator?: Options['sortComparator']) => {
@@ -140,8 +170,8 @@ export const useChannelMessagesReducer = (sortComparator?: Options['sortComparat
   };
 
   const messages = useIIFE(() => {
-    if (sortComparator) return Object.values(messageMap).sort(sortComparator);
-    return Object.values(messageMap);
+    if (sortComparator) return Array.from(new Set(Object.values(messageMap))).sort(sortComparator);
+    return Array.from(new Set(Object.values(messageMap)));
   });
   const newMessages = Object.values(newMessageMap);
 

--- a/packages/uikit-chat-hooks/src/channel/useChannelMessagesReducer.ts
+++ b/packages/uikit-chat-hooks/src/channel/useChannelMessagesReducer.ts
@@ -57,7 +57,7 @@ const defaultReducer = ({ ...draft }: State, action: Action) => {
         // Filtering meaningless message updates
         const nextMessages = action.value.messages.filter((next) => {
           if (isMyMessage(next, userId)) {
-            const prev = draft['messageMap'][next.reqId] || draft['messageMap'][next.messageId];
+            const prev = draft['messageMap'][next.reqId] ?? draft['messageMap'][next.messageId];
             if (isMyMessage(prev, userId)) {
               const shouldUpdate = shouldUpdateMessage(prev, next);
               if (shouldUpdate) {

--- a/packages/uikit-testing-tools/src/mocks/createMockMessage.ts
+++ b/packages/uikit-testing-tools/src/mocks/createMockMessage.ts
@@ -22,31 +22,49 @@ const tc = createTestContext();
 class MockMessage implements GetMockProps<Params, SendbirdBaseMessage> {
   constructor(public params: Params) {
     tc.increaseIncrement();
-    this.__updateIdsBySendingStatus();
+    this.__updateIdsBySendingStatus(params);
     Object.assign(this, params);
   }
 
-  __updateIdsBySendingStatus() {
-    if (!this.params.sendingStatus) return;
+  __updateIdsBySendingStatus(params: Params) {
+    if (!params.sendingStatus) return;
 
     const self = this.asSendableMessage();
-    const notSent = [SendingStatus.PENDING, SendingStatus.FAILED, SendingStatus.CANCELED].some(
-      (it) => this.params.sendingStatus === it,
+    self.reqId = String(Date.now()) + tc.increment;
+
+    const unsent = [SendingStatus.PENDING, SendingStatus.FAILED, SendingStatus.CANCELED].some(
+      (it) => params.sendingStatus === it,
     );
-    if (notSent) {
+    if (unsent) {
       self.messageId = 0;
-      self.reqId = String(Date.now()) + tc.increment;
     } else {
       self.messageId = tc.getRandom();
-      self.reqId = '';
     }
   }
 
-  channelType: ChannelType = ChannelType.BASE;
-  channelUrl: string = 'channel_url_' + tc.getHash();
-  createdAt: number = tc.date + tc.increment;
-  messageId: number = tc.getRandom();
+  channelType = ChannelType.BASE;
+  channelUrl = 'channel_url_' + tc.getHash();
+  createdAt = tc.date + tc.increment;
+  updatedAt = 0;
+  messageId = tc.getRandom();
   messageType = MessageType.BASE;
+  parentMessageId = 0;
+  parentMessage = null;
+  silent = false;
+  isOperatorMessage = false;
+  data = '';
+  customType = '';
+  mentionType = null;
+  mentionedUsers = null;
+  mentionedUserIds = null;
+  mentionedMessageTemplate = '';
+  threadInfo = null;
+  reactions = [];
+  metaArrays = [];
+  ogMetaData = null;
+  appleCriticalAlertOptions = null;
+  scheduledInfo = null;
+  extendedMessage = {};
 
   isFileMessage(): this is SendbirdFileMessage {
     return this.messageType === MessageType.FILE && !Object.prototype.hasOwnProperty.call(this, 'fileInfoList');


### PR DESCRIPTION
[CLNP-630]

## Description Of Changes

현재 메세지 리스트는 오브젝트 형태로 관리하고 있습니다.

```ts
{
  [outgoingMessage.reqId]: BaseMessage;
  [incomingMessage.messageId]: BaseMessage;
}
```

원래 전송된 메세지는 messageId, 전송안된 메세지는 reqId 를 키로 사용하다가
내가 전송한 메세지는 모두 reqId 를 사용하도록 변경했고
이렇게 변경한 이유는 아래 케이스를 처리 하기 위함이었는데요

1. pending (messageRequestHandler)
2. succeeded (messageRequestHandler)
3. pending (collectionHandler)
4. succeeded (collectionHandler)

이미 내가 전송한 메세지가 succeeded 된 상태에서, pending message 업데이트가 들어올 경우
reqId 로 오브젝트에서 prev 메세지를 찾아서  `sendingStatus` 를 체크하기 위함이었습니다.

그런데 `channel.updateUserMessage` 와 같은 메소드로, 메세지를 업데이트 할 경우 `reqId` 가 변경됩니다.
업데이트 된 메세지의 새로운 reqId 는 오브젝트에 없기 때문에, 중복된 메세지로 추가되는 이슈가 있었습니다.

이를 방지하기 위해서 아래처럼 outgoingMessage 의 messageId 도 추가 하여
reqId/mesageId 로 오브젝트에서 prev 메세지를 찾도록 변경하고
메세지 리스트 오브젝트를 배열로 변경하여 반환할때는, 중복을 제거하는 처리를 추가했습니다.

```ts
{
  [outgoingMessage.reqId]: BaseMessage;
  [outgoingMessage.messageId]: BaseMessage; // succeeded 상태일 경우에만 추가
  [incomingMessage.messageId]: BaseMessage;
}
```

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-630]: https://sendbird.atlassian.net/browse/CLNP-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ