### PR TITLE
feat(CLNP-1147): add reaction.onPressUserProfile to SendbirdUIKitContainer props

### DIFF
--- a/packages/uikit-react-native/src/components/ReactionBottomSheets/ReactionUserListBottomSheet.tsx
+++ b/packages/uikit-react-native/src/components/ReactionBottomSheets/ReactionUserListBottomSheet.tsx
@@ -22,7 +22,7 @@ const ReactionUserListBottomSheet = ({
   reactionCtx,
   chatCtx,
   localizationCtx,
-  userProfileCtx,
+  onPressUserProfile,
 }: ReactionBottomSheetProps) => {
   const { width } = useWindowDimensions();
   const { bottom, left, right } = useSafeAreaInsets();
@@ -134,7 +134,7 @@ const ReactionUserListBottomSheet = ({
                 onPress={async () => {
                   if (user) {
                     await onClose();
-                    userProfileCtx.show(user);
+                    onPressUserProfile(user);
                   }
                 }}
                 style={styles.pageItem}

--- a/packages/uikit-react-native/src/components/ReactionBottomSheets/index.tsx
+++ b/packages/uikit-react-native/src/components/ReactionBottomSheets/index.tsx
@@ -1,9 +1,10 @@
 import type React from 'react';
 
+import type { SendbirdMember, SendbirdUser } from '@sendbird/uikit-utils';
+
 import type { LocalizationContext } from '../../contexts/LocalizationCtx';
 import type { ReactionContext } from '../../contexts/ReactionCtx';
 import type { SendbirdChatContext } from '../../contexts/SendbirdChatCtx';
-import type { UserProfileContext } from '../../contexts/UserProfileCtx';
 import ReactionList from './ReactionListBottomSheet';
 import UserList from './ReactionUserListBottomSheet';
 
@@ -12,10 +13,10 @@ export type ReactionBottomSheetProps = {
   visible: boolean;
   onDismiss: () => void;
   onClose: () => Promise<void>;
+  onPressUserProfile: (user: SendbirdUser | SendbirdMember) => void;
   chatCtx: GetFromContext<typeof SendbirdChatContext>;
   reactionCtx: GetFromContext<typeof ReactionContext>;
   localizationCtx: GetFromContext<typeof LocalizationContext>;
-  userProfileCtx: GetFromContext<typeof UserProfileContext>;
 };
 
 export const ReactionBottomSheets = {

--- a/packages/uikit-react-native/src/containers/SendbirdUIKitContainer.tsx
+++ b/packages/uikit-react-native/src/containers/SendbirdUIKitContainer.tsx
@@ -110,6 +110,9 @@ export type SendbirdUIKitContainerProps = React.PropsWithChildren<{
       users: SendbirdUser[] | SendbirdMember[],
     ) => SendbirdGroupChannelCreateParams | Promise<SendbirdGroupChannelCreateParams>;
   };
+  reaction?: {
+    onPressUserProfile?: (user: SendbirdUser | SendbirdMember) => void;
+  };
   userMention?: Pick<Partial<MentionConfigInterface>, 'mentionLimit' | 'suggestionLimit' | 'debounceMills'>;
   imageCompression?: Partial<ImageCompressionConfigInterface>;
 }>;
@@ -125,6 +128,7 @@ const SendbirdUIKitContainer = ({
   errorBoundary,
   toast,
   userProfile,
+  reaction,
   userMention,
   imageCompression,
 }: SendbirdUIKitContainerProps) => {
@@ -232,12 +236,8 @@ const SendbirdUIKitContainer = ({
                   statusBarTranslucent={styles?.statusBarTranslucent ?? true}
                 >
                   <ToastProvider dismissTimeout={toast?.dismissTimeout}>
-                    <UserProfileProvider
-                      onCreateChannel={userProfile?.onCreateChannel}
-                      onBeforeCreateChannel={userProfile?.onBeforeCreateChannel}
-                      statusBarTranslucent={styles?.statusBarTranslucent ?? true}
-                    >
-                      <ReactionProvider>
+                    <UserProfileProvider {...userProfile} statusBarTranslucent={styles?.statusBarTranslucent ?? true}>
+                      <ReactionProvider {...reaction}>
                         <LocalizationContext.Consumer>
                           {(value) => {
                             const STRINGS = value?.STRINGS || defaultStringSet;

--- a/packages/uikit-react-native/src/contexts/ReactionCtx.tsx
+++ b/packages/uikit-react-native/src/contexts/ReactionCtx.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useContext, useReducer, useRef, useState } from 're
 import type { SendbirdBaseChannel, SendbirdBaseMessage } from '@sendbird/uikit-utils';
 import { NOOP } from '@sendbird/uikit-utils';
 
-import { ReactionBottomSheets } from '../components/ReactionBottomSheets';
+import { ReactionBottomSheetProps, ReactionBottomSheets } from '../components/ReactionBottomSheets';
 import { LocalizationContext } from '../contexts/LocalizationCtx';
 import { SendbirdChatContext } from '../contexts/SendbirdChatCtx';
 import { UserProfileContext } from '../contexts/UserProfileCtx';
@@ -19,10 +19,12 @@ export type ReactionContextType = {
   focusIndex: number;
 } & State;
 
-type Props = React.PropsWithChildren<{}>;
+type Props = React.PropsWithChildren<{
+  onPressUserProfile?: ReactionBottomSheetProps['onPressUserProfile'];
+}>;
 
 export const ReactionContext = React.createContext<ReactionContextType | null>(null);
-export const ReactionProvider = ({ children }: Props) => {
+export const ReactionProvider = ({ children, onPressUserProfile }: Props) => {
   const chatCtx = useContext(SendbirdChatContext);
   const localizationCtx = useContext(LocalizationContext);
   const userProfileCtx = useContext(UserProfileContext);
@@ -73,11 +75,11 @@ export const ReactionProvider = ({ children }: Props) => {
     focusIndex: reactionUserListFocusIndex,
   };
 
-  const sheetProps = {
+  const sheetProps: Omit<ReactionBottomSheetProps, 'visible' | 'onClose'> = {
     chatCtx,
     reactionCtx,
     localizationCtx,
-    userProfileCtx,
+    onPressUserProfile: onPressUserProfile ?? userProfileCtx.show,
     onDismiss: () => {
       setState({});
       closeResolver.current?.();


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[CLNP-1147]

## Description Of Changes

- **Add a `reaction.onPressUserProfile` to SendbirdUIKitContainer props**
  onPress handler for below area<br/>
   <img style="border:1px solid black" width="326" alt="screenshot" src="https://github.com/sendbird/sendbird-uikit-react-native/assets/26326015/13f923c3-ecf7-4e38-b39c-5758b937577f">


## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-1147]: https://sendbird.atlassian.net/browse/CLNP-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ