### PR TITLE
fix crash when recorderService is undefined

### DIFF
--- a/packages/uikit-react-native/src/contexts/PlatformServiceCtx.tsx
+++ b/packages/uikit-react-native/src/contexts/PlatformServiceCtx.tsx
@@ -25,8 +25,10 @@ type Props = React.PropsWithChildren<PlatformServiceContextType & { voiceMessage
 export const PlatformServiceContext = React.createContext<PlatformServiceContextType | null>(null);
 export const PlatformServiceProvider = ({ children, voiceMessageConfig, ...services }: Props) => {
   useEffect(() => {
-    services.recorderService.options.minDuration = voiceMessageConfig.recorder.minDuration;
-    services.recorderService.options.maxDuration = voiceMessageConfig.recorder.maxDuration;
+    if (services.recorderService !== undefined) {
+      services.recorderService.options.minDuration = voiceMessageConfig.recorder.minDuration;
+      services.recorderService.options.maxDuration = voiceMessageConfig.recorder.maxDuration;
+    }
   }, [voiceMessageConfig]);
 
   useAppState('change', (state) => {


### PR DESCRIPTION
## Description Of Changes

I was getting an error of an undefined `recorderService`.

```
 ERROR  TypeError: Cannot read property 'options' of undefined

This error is located at:
    in PlatformServiceProvider (created by SendbirdUIKitContainer)
    in LocalizationProvider (created by SendbirdUIKitContainer)
    in SendbirdChatProvider (created by SendbirdUIKitContainer)
    in UIKitConfigProvider (created by SendbirdUIKitContainer)
```

This PR fixes this issue.

## Types Of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test
