### PR TITLE
chore(CLNP-2179): introduced new list query params

### DIFF
--- a/packages/uikit-chat-hooks/src/channel/useGroupChannelList/index.ts
+++ b/packages/uikit-chat-hooks/src/channel/useGroupChannelList/index.ts
@@ -4,6 +4,9 @@ import type { UseGroupChannelList } from '../../types';
 import { useGroupChannelListWithCollection } from './useGroupChannelListWithCollection';
 import { useGroupChannelListWithQuery } from './useGroupChannelListWithQuery';
 
+/**
+ * @deprecated This hook is deprecated and will be replaced by the 'uikit-tools' package.
+ * */
 export const useGroupChannelList: UseGroupChannelList = (sdk, userId, options) => {
   if (sdk.isCacheEnabled || options?.enableCollectionWithoutLocalCache) {
     if (options?.queryCreator) Logger.warn('`queryCreator` is ignored, please use `collectionCreator` instead.');

--- a/packages/uikit-chat-hooks/src/types.ts
+++ b/packages/uikit-chat-hooks/src/types.ts
@@ -33,6 +33,8 @@ export interface CustomBidirectionalQueryInterface<Data> {
 }
 
 /**
+ * @deprecated This hook is deprecated and will be replaced by the 'uikit-tools' package.
+ *
  * @interface UseGroupChannelList
  * @description interface for group channel list hook
  * */

--- a/packages/uikit-react-native/__template__/types.ts
+++ b/packages/uikit-react-native/__template__/types.ts
@@ -33,4 +33,4 @@ export interface __domain__Module {
   StatusLoading: CommonComponent;
 }
 
-export type __domain__Fragment = CommonComponent<__domain__Props['Fragment']>;
+export type __domain__Fragment = React.FC<__domain__Props['Fragment']>;

--- a/packages/uikit-react-native/src/domain/groupChannel/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannel/types.ts
@@ -1,6 +1,7 @@
 import type React from 'react';
 import type { FlatList } from 'react-native';
 
+import type { MessageCollectionParams, MessageFilterParams } from '@sendbird/chat/groupChannel';
 import type { UseGroupChannelMessagesOptions } from '@sendbird/uikit-chat-hooks';
 import type {
   OnBeforeHandler,
@@ -20,6 +21,7 @@ import type { ChannelMessageListProps } from '../../components/ChannelMessageLis
 import type { CommonComponent } from '../../types';
 import type { PubSub } from '../../utils/pubsub';
 
+export type MessageListQueryParamsType = Omit<MessageCollectionParams, 'filter'> & MessageFilterParams;
 export interface GroupChannelProps {
   Fragment: {
     channel: SendbirdGroupChannel;
@@ -43,9 +45,19 @@ export interface GroupChannelProps {
     keyboardAvoidOffset?: GroupChannelProps['Provider']['keyboardAvoidOffset'];
     flatListProps?: GroupChannelProps['MessageList']['flatListProps'];
     sortComparator?: UseGroupChannelMessagesOptions['sortComparator'];
-    collectionCreator?: UseGroupChannelMessagesOptions['collectionCreator'];
 
     searchItem?: GroupChannelProps['MessageList']['searchItem'];
+
+    /**
+     * @description You can specify the query parameters for the message list.
+     * @example
+     * ```
+     * <GroupChannelFragment messageListQueryParams={{ prevResultLimit: 20, customTypesFilter: ['filter'] }} />
+     * ```
+     * */
+    messageListQueryParams?: MessageListQueryParamsType;
+    /** @deprecated Please use `messageListQueryParams` instead */
+    collectionCreator?: UseGroupChannelMessagesOptions['collectionCreator'];
   };
   Header: {
     shouldHideRight: () => boolean;

--- a/packages/uikit-react-native/src/domain/groupChannel/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannel/types.ts
@@ -169,7 +169,7 @@ export interface GroupChannelModule {
   StatusLoading: CommonComponent;
 }
 
-export type GroupChannelFragment = CommonComponent<GroupChannelProps['Fragment']>;
+export type GroupChannelFragment = React.FC<GroupChannelProps['Fragment']>;
 
 export type GroupChannelPubSubContextPayload =
   | {

--- a/packages/uikit-react-native/src/domain/groupChannelBannedUsers/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelBannedUsers/types.ts
@@ -49,4 +49,4 @@ export interface GroupChannelBannedUsersModule {
   StatusError: CommonComponent<GroupChannelBannedUsersProps['StatusError']>;
 }
 
-export type GroupChannelBannedUsersFragment = CommonComponent<GroupChannelBannedUsersProps['Fragment']>;
+export type GroupChannelBannedUsersFragment = React.FC<GroupChannelBannedUsersProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/groupChannelList/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelList/types.ts
@@ -72,5 +72,5 @@ export interface GroupChannelListModule {
   StatusLoading: CommonComponent;
 }
 
-export type GroupChannelListFragment = CommonComponent<GroupChannelListProps['Fragment']>;
+export type GroupChannelListFragment = React.FC<GroupChannelListProps['Fragment']>;
 export type GroupChannelType = 'GROUP' | 'SUPER_GROUP' | 'BROADCAST';

--- a/packages/uikit-react-native/src/domain/groupChannelList/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelList/types.ts
@@ -1,21 +1,32 @@
 import type React from 'react';
 import type { FlatListProps } from 'react-native';
 
+import type { GroupChannelCollectionParams, GroupChannelFilterParams } from '@sendbird/chat/groupChannel';
 import type { UseGroupChannelListOptions } from '@sendbird/uikit-chat-hooks';
 import type { ActionMenuItem } from '@sendbird/uikit-react-native-foundation';
 import type { SendbirdGroupChannel } from '@sendbird/uikit-utils';
 
 import type { CommonComponent } from '../../types';
 
+export type ChannelListQueryParamsType = Omit<GroupChannelCollectionParams, 'filter'> & GroupChannelFilterParams;
 export interface GroupChannelListProps {
   Fragment: {
     onPressChannel: GroupChannelListProps['List']['onPressChannel'];
     onPressCreateChannel: (channelType: GroupChannelType) => void;
     renderGroupChannelPreview?: GroupChannelListProps['List']['renderGroupChannelPreview'];
     skipTypeSelection?: boolean;
-    collectionCreator?: UseGroupChannelListOptions['collectionCreator'];
     flatListProps?: GroupChannelListProps['List']['flatListProps'];
     menuItemCreator?: GroupChannelListProps['List']['menuItemCreator'];
+    /**
+     * @description You can specify the query parameters for the channel list.
+     * @example
+     * ```
+     * <GroupChannelListFragment channelListQueryParams={{ limit: 20, includeEmpty: false }} />
+     * ```
+     * */
+    channelListQueryParams?: ChannelListQueryParamsType;
+    /** @deprecated Please use `channelListQueryParams` instead */
+    collectionCreator?: UseGroupChannelListOptions['collectionCreator'];
   };
   Header: {};
   List: {

--- a/packages/uikit-react-native/src/domain/groupChannelModeration/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelModeration/types.ts
@@ -45,4 +45,4 @@ export interface GroupChannelModerationModule {
   Menu: CommonComponent<GroupChannelModerationProps['Menu']>;
 }
 
-export type GroupChannelModerationFragment = CommonComponent<GroupChannelModerationProps['Fragment']>;
+export type GroupChannelModerationFragment = React.FC<GroupChannelModerationProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/groupChannelMutedMembers/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelMutedMembers/types.ts
@@ -49,4 +49,4 @@ export interface GroupChannelMutedMembersModule {
   StatusError: CommonComponent<GroupChannelMutedMembersProps['StatusError']>;
 }
 
-export type GroupChannelMutedMembersFragment = CommonComponent<GroupChannelMutedMembersProps['Fragment']>;
+export type GroupChannelMutedMembersFragment = React.FC<GroupChannelMutedMembersProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/groupChannelNotifications/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelNotifications/types.ts
@@ -35,4 +35,4 @@ export interface GroupChannelNotificationsModule {
   View: CommonComponent<GroupChannelNotificationsProps['View']>;
 }
 
-export type GroupChannelNotificationsFragment = CommonComponent<GroupChannelNotificationsProps['Fragment']>;
+export type GroupChannelNotificationsFragment = React.FC<GroupChannelNotificationsProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/groupChannelOperators/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelOperators/types.ts
@@ -51,4 +51,4 @@ export interface GroupChannelOperatorsModule {
   StatusError: CommonComponent<GroupChannelOperatorsProps['StatusError']>;
 }
 
-export type GroupChannelOperatorsFragment = CommonComponent<GroupChannelOperatorsProps['Fragment']>;
+export type GroupChannelOperatorsFragment = React.FC<GroupChannelOperatorsProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/groupChannelSettings/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelSettings/types.ts
@@ -53,4 +53,4 @@ export interface GroupChannelSettingsModule {
   Menu: CommonComponent<GroupChannelSettingsProps['Menu']>;
 }
 
-export type GroupChannelSettingsFragment = CommonComponent<GroupChannelSettingsProps['Fragment']>;
+export type GroupChannelSettingsFragment = React.FC<GroupChannelSettingsProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/groupChannelUserList/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannelUserList/types.ts
@@ -52,7 +52,7 @@ export interface GroupChannelMembersProps {
     queryCreator?: UseUserListOptions<SendbirdMember>['queryCreator'];
   };
 }
-export type GroupChannelMembersFragment = CommonComponent<GroupChannelMembersProps['Fragment']>;
+export type GroupChannelMembersFragment = React.FC<GroupChannelMembersProps['Fragment']>;
 
 export interface GroupChannelRegisterOperatorProps {
   Fragment: {
@@ -64,4 +64,4 @@ export interface GroupChannelRegisterOperatorProps {
     queryCreator?: UseUserListOptions<SendbirdMember>['queryCreator'];
   };
 }
-export type GroupChannelRegisterOperatorFragment = CommonComponent<GroupChannelRegisterOperatorProps['Fragment']>;
+export type GroupChannelRegisterOperatorFragment = React.FC<GroupChannelRegisterOperatorProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/messageSearch/types.ts
+++ b/packages/uikit-react-native/src/domain/messageSearch/types.ts
@@ -52,4 +52,4 @@ export interface MessageSearchModule {
   StatusError: CommonComponent<MessageSearchProps['StatusError']>;
 }
 
-export type MessageSearchFragment = CommonComponent<MessageSearchProps['Fragment']>;
+export type MessageSearchFragment = React.FC<MessageSearchProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/openChannel/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannel/types.ts
@@ -111,7 +111,7 @@ export interface OpenChannelModule {
   StatusLoading: CommonComponent;
 }
 
-export type OpenChannelFragment = CommonComponent<OpenChannelProps['Fragment']>;
+export type OpenChannelFragment = React.FC<OpenChannelProps['Fragment']>;
 
 export type OpenChannelPubSubContextPayload =
   | {

--- a/packages/uikit-react-native/src/domain/openChannelBannedUsers/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannelBannedUsers/types.ts
@@ -49,4 +49,4 @@ export interface OpenChannelBannedUsersModule {
   StatusError: CommonComponent<OpenChannelBannedUsersProps['StatusError']>;
 }
 
-export type OpenChannelBannedUsersFragment = CommonComponent<OpenChannelBannedUsersProps['Fragment']>;
+export type OpenChannelBannedUsersFragment = React.FC<OpenChannelBannedUsersProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/openChannelCreate/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannelCreate/types.ts
@@ -42,4 +42,4 @@ export interface OpenChannelCreateModule {
   StatusLoading: CommonComponent;
 }
 
-export type OpenChannelCreateFragment = CommonComponent<OpenChannelCreateProps['Fragment']>;
+export type OpenChannelCreateFragment = React.FC<OpenChannelCreateProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/openChannelList/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannelList/types.ts
@@ -53,4 +53,4 @@ export interface OpenChannelListModule {
   StatusError: CommonComponent<OpenChannelListProps['StatusError']>;
 }
 
-export type OpenChannelListFragment = CommonComponent<OpenChannelListProps['Fragment']>;
+export type OpenChannelListFragment = React.FC<OpenChannelListProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/openChannelModeration/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannelModeration/types.ts
@@ -45,4 +45,4 @@ export interface OpenChannelModerationModule {
   Menu: CommonComponent<OpenChannelModerationProps['Menu']>;
 }
 
-export type OpenChannelModerationFragment = CommonComponent<OpenChannelModerationProps['Fragment']>;
+export type OpenChannelModerationFragment = React.FC<OpenChannelModerationProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/openChannelMutedParticipants/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannelMutedParticipants/types.ts
@@ -49,4 +49,4 @@ export interface OpenChannelMutedParticipantsModule {
   StatusError: CommonComponent<OpenChannelMutedParticipantsProps['StatusError']>;
 }
 
-export type OpenChannelMutedParticipantsFragment = CommonComponent<OpenChannelMutedParticipantsProps['Fragment']>;
+export type OpenChannelMutedParticipantsFragment = React.FC<OpenChannelMutedParticipantsProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/openChannelOperators/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannelOperators/types.ts
@@ -51,4 +51,4 @@ export interface OpenChannelOperatorsModule {
   StatusError: CommonComponent<OpenChannelOperatorsProps['StatusError']>;
 }
 
-export type OpenChannelOperatorsFragment = CommonComponent<OpenChannelOperatorsProps['Fragment']>;
+export type OpenChannelOperatorsFragment = React.FC<OpenChannelOperatorsProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/openChannelSettings/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannelSettings/types.ts
@@ -51,4 +51,4 @@ export interface OpenChannelSettingsModule {
   Menu: CommonComponent<OpenChannelSettingsProps['Menu']>;
 }
 
-export type OpenChannelSettingsFragment = CommonComponent<OpenChannelSettingsProps['Fragment']>;
+export type OpenChannelSettingsFragment = React.FC<OpenChannelSettingsProps['Fragment']>;

--- a/packages/uikit-react-native/src/domain/openChannelUserList/types.ts
+++ b/packages/uikit-react-native/src/domain/openChannelUserList/types.ts
@@ -1,7 +1,8 @@
+import type React from 'react';
+
 import type { UseUserListOptions } from '@sendbird/uikit-chat-hooks';
 import type { SendbirdOpenChannel, SendbirdParticipant, SendbirdUser } from '@sendbird/uikit-utils';
 
-import type { CommonComponent } from '../../types';
 import type { UserListProps } from '../userList/types';
 
 export interface OpenChannelParticipantsProps {
@@ -14,7 +15,7 @@ export interface OpenChannelParticipantsProps {
     sortComparator?: UseUserListOptions<SendbirdUser | SendbirdParticipant>['sortComparator'];
   };
 }
-export type OpenChannelParticipantsFragment = CommonComponent<OpenChannelParticipantsProps['Fragment']>;
+export type OpenChannelParticipantsFragment = React.FC<OpenChannelParticipantsProps['Fragment']>;
 
 export interface OpenChannelRegisterOperatorProps {
   Fragment: {
@@ -27,4 +28,4 @@ export interface OpenChannelRegisterOperatorProps {
     sortComparator?: UseUserListOptions<SendbirdUser | SendbirdParticipant>['sortComparator'];
   };
 }
-export type OpenChannelRegisterOperatorFragment = CommonComponent<OpenChannelRegisterOperatorProps['Fragment']>;
+export type OpenChannelRegisterOperatorFragment = React.FC<OpenChannelRegisterOperatorProps['Fragment']>;

--- a/sample/src/screens/uikit/groupChannel/GroupChannelScreen.tsx
+++ b/sample/src/screens/uikit/groupChannel/GroupChannelScreen.tsx
@@ -97,6 +97,10 @@ const GroupChannelScreen = () => {
         // Navigate to group channel settings
         navigation.push(Routes.GroupChannelSettings, params);
       }}
+      // messageListQueryParams={{
+      //   prevResultLimit: 20,
+      //   customTypesFilter: ['filter'],
+      // }}
     />
   );
 };

--- a/sample/src/screens/uikit/groupChannel/GroupChannelTabs/GroupChannelListScreen.tsx
+++ b/sample/src/screens/uikit/groupChannel/GroupChannelTabs/GroupChannelListScreen.tsx
@@ -63,6 +63,10 @@ const GroupChannelListScreen = () => {
       onPressChannel={(channel) => {
         navigation.navigate(Routes.GroupChannel, { channelUrl: channel.url });
       }}
+      // channelListQueryParams={{
+      //   includeEmpty: true,
+      //   includeFrozen: false,
+      // }}
     />
   );
 };


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[CLNP-2179]

## Description Of Changes
- Add `messageListQueryParams` to `GroupChannelFragment`.
- Add `channelListQueryParams` to `GroupChannelListFragment`.
- Deprecate the `collectionCreator` prop from `GroupChannelFragment` and `GroupChannelListFragment`.
- Deprecate the use of `useGroupChannelList` in `uikit-chat-hooks`.
- Fix Fragment types for finding the correct props place in the IDE.

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [x] Improvement (refactor code)
- [ ] Test


[CLNP-2179]: https://sendbird.atlassian.net/browse/CLNP-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ