### PR TITLE
feat(CLNP-2540): add disableFastImage prop to Image component

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     ]
   },
   "resolutions": {
-    "@sendbird/chat": "4.10.7",
+    "@sendbird/chat": "4.11.2",
     "@types/react": "^18",
     "@types/react-native": "^0.67"
   }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     ]
   },
   "resolutions": {
-    "@sendbird/chat": "4.11.2",
+    "@sendbird/chat": "4.11.3",
     "@types/react": "^18",
     "@types/react-native": "^0.67"
   }

--- a/packages/uikit-react-native-foundation/src/components/Image/Image.fastimage.tsx
+++ b/packages/uikit-react-native-foundation/src/components/Image/Image.fastimage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Image } from 'react-native';
 import type { FastImageProps, ResizeMode, Source } from 'react-native-fast-image';
 
 import FastImageInternal from './FastImageInternal';
@@ -61,8 +62,21 @@ const Image_FastImage: SendbirdImageComponent = ({
   onLoad,
   onError,
   style,
+  tintColor,
+  disableFastImage,
   ...props
 }) => {
+  if (disableFastImage) {
+    return (
+      <Image
+        {...props}
+        source={source}
+        style={[style, { tintColor }]}
+        onError={onError && ((e) => onError(e.nativeEvent))}
+        onLoad={onLoad && ((e) => onLoad(e.nativeEvent.source))}
+      />
+    );
+  }
   return (
     <FastImageInternal
       {...props}

--- a/packages/uikit-react-native-foundation/src/components/Image/index.ts
+++ b/packages/uikit-react-native-foundation/src/components/Image/index.ts
@@ -1,15 +1,15 @@
-import { ReactNode } from 'react';
+import { ComponentType } from 'react';
 import type { ImageProps as NativeImageProps } from 'react-native';
 import { NativeModules } from 'react-native';
 
 export interface SendbirdImageProps extends Omit<NativeImageProps, 'onLoad' | 'onError'> {
+  disableFastImage?: boolean;
   onLoad?: (event: { width: number; height: number }) => void;
   onError?: (event: { error?: unknown }) => void;
   tintColor?: string;
 }
 
-export type SendbirdImageComponent = (props: SendbirdImageProps) => ReactNode;
-
+export type SendbirdImageComponent = ComponentType<SendbirdImageProps>;
 function getImageModule(): SendbirdImageComponent {
   const hasFastImage = Boolean(NativeModules.FastImageView);
   if (hasFastImage) {
@@ -23,4 +23,10 @@ function getImageModule(): SendbirdImageComponent {
   }
 }
 
-export default getImageModule();
+const Image = getImageModule();
+
+Image.defaultProps = {
+  disableFastImage: false,
+};
+
+export default Image;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3379,10 +3379,10 @@
   dependencies:
     nanoid "^3.1.23"
 
-"@sendbird/chat@4.11.2", "@sendbird/chat@^4.10.7":
-  version "4.11.2"
-  resolved "https://registry.yarnpkg.com/@sendbird/chat/-/chat-4.11.2.tgz#e223ef121ce3b610d9f51f002e7230b02f6c165e"
-  integrity sha512-ea9GZ+vZdbHpsrCnexQh1fKxw52GfwH/D7NYAgt7mzSzoiL2KIViYL7FpwLifFHDtdMprdgoIZBUzOTwtf21rQ==
+"@sendbird/chat@4.11.3", "@sendbird/chat@^4.10.7":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@sendbird/chat/-/chat-4.11.3.tgz#f0f6b2c1da3c24fd27f49221ccfde02105b30951"
+  integrity sha512-I5OIWBL4jdVHvBn2UqJZJkcE+sXPOVVxZFtJfK3FrllkT9hDtCLzCi5GPWnh0X73vr+WBLY6KSw27y4dZfIPEg==
 
 "@sendbird/react-native-scrollview-enhancer@^0.2.1":
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3379,10 +3379,10 @@
   dependencies:
     nanoid "^3.1.23"
 
-"@sendbird/chat@4.10.7", "@sendbird/chat@^4.10.7":
-  version "4.10.7"
-  resolved "https://registry.yarnpkg.com/@sendbird/chat/-/chat-4.10.7.tgz#45b23849a854273811c36a072044e64c6a0bc4bd"
-  integrity sha512-68h9sj5mMaBzYMfcX0G7TU91JMrGRz0rbUJj6pSLet911pRMBpUi0f6smS8XtUJMNdXtwFh56TyMyAZQM6TcCQ==
+"@sendbird/chat@4.11.2", "@sendbird/chat@^4.10.7":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@sendbird/chat/-/chat-4.11.2.tgz#e223ef121ce3b610d9f51f002e7230b02f6c165e"
+  integrity sha512-ea9GZ+vZdbHpsrCnexQh1fKxw52GfwH/D7NYAgt7mzSzoiL2KIViYL7FpwLifFHDtdMprdgoIZBUzOTwtf21rQ==
 
 "@sendbird/react-native-scrollview-enhancer@^0.2.1":
   version "0.2.1"


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[CLNP-2540]

## Description Of Changes

Add a brief description of the changes that you have involved in this PR

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test

---

### Usage
```ts
import { Image } from '@sendbird/uikit-react-native-foundation';

// If you don't want to use FastImage in UIKit for React Native, you can specify this default prop
if (Image.defaultProps) Image.defaultProps.disableFastImage = true;
```

[CLNP-2540]: https://sendbird.atlassian.net/browse/CLNP-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ