### PR TITLE
feat(CLNP-3585): deprecated enableReactionsSupergroup

### DIFF
--- a/packages/uikit-react-native/package.json
+++ b/packages/uikit-react-native/package.json
@@ -62,7 +62,7 @@
     "@openspacelabs/react-native-zoomable-view": "^2.1.5",
     "@sendbird/uikit-chat-hooks": "3.5.3",
     "@sendbird/uikit-react-native-foundation": "3.5.3",
-    "@sendbird/uikit-tools": "0.0.1-alpha.66",
+    "@sendbird/uikit-tools": "0.0.1-alpha.76",
     "@sendbird/uikit-utils": "3.5.3"
   },
   "devDependencies": {

--- a/packages/uikit-react-native/src/containers/SendbirdUIKitContainer.tsx
+++ b/packages/uikit-react-native/src/containers/SendbirdUIKitContainer.tsx
@@ -64,7 +64,7 @@ export const SendbirdUIKit = Object.freeze({
   },
 });
 
-type UnimplementedFeatures = 'threadReplySelectType' | 'replyType';
+type UnimplementedFeatures = 'threadReplySelectType' | 'replyType' | 'enableReactionsSupergroup';
 export type ChatOmittedInitParams = Omit<
   SendbirdChatParams<[GroupChannelModule, OpenChannelModule]>,
   (typeof chatOmitKeys)[number]
@@ -104,6 +104,10 @@ export type SendbirdUIKitContainerProps = React.PropsWithChildren<{
     common: SBUConfig['common'];
     groupChannel: Omit<SBUConfig['groupChannel']['channel'], UnimplementedFeatures> & {
       replyType: Extract<SBUConfig['groupChannel']['channel']['replyType'], 'none' | 'quote_reply'>;
+      /**
+       * @deprecated Currently, this feature is turned off by default. If you wish to use this feature, contact us: {@link https://dashboard.sendbird.com/settings/contact_us?category=feedback_and_feature_requests&product=UIKit}
+       */
+      enableReactionsSupergroup: never;
     };
     groupChannelList: SBUConfig['groupChannel']['channelList'];
     groupChannelSettings: SBUConfig['groupChannel']['setting'];
@@ -208,7 +212,7 @@ const SendbirdUIKitContainer = (props: SendbirdUIKitContainerProps) => {
         localConfigs={{
           common: uikitOptions?.common,
           groupChannel: {
-            channel: uikitOptions?.groupChannel,
+            channel: { ...uikitOptions?.groupChannel, enableReactionsSupergroup: undefined },
             channelList: uikitOptions?.groupChannelList,
             setting: uikitOptions?.groupChannelSettings,
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3389,10 +3389,10 @@
   resolved "https://registry.yarnpkg.com/@sendbird/react-native-scrollview-enhancer/-/react-native-scrollview-enhancer-0.2.1.tgz#25de4af78293978a4c0ef6fddee25d822a364c46"
   integrity sha512-LN+Tm+ZUkE2MBVreg/JI8SVr8SOKRteZN0YFpGzRtbKkP45+pKyPN4JQPf73eFx7qO8zDL+TUVyzz/1MOnIK7g==
 
-"@sendbird/uikit-tools@0.0.1-alpha.66":
-  version "0.0.1-alpha.66"
-  resolved "https://registry.yarnpkg.com/@sendbird/uikit-tools/-/uikit-tools-0.0.1-alpha.66.tgz#5328f1768c130b15cdec9f0ab9f21d2da269ba62"
-  integrity sha512-IE8HHqTcAVunnVhcfsxQCRmOoCNHx3c8ZP3eZeqYJB876DrnM38ne5TZVao2ZFSmbiZZQ7xc9DClEiZuZUgvnQ==
+"@sendbird/uikit-tools@0.0.1-alpha.76":
+  version "0.0.1-alpha.76"
+  resolved "https://registry.yarnpkg.com/@sendbird/uikit-tools/-/uikit-tools-0.0.1-alpha.76.tgz#7f293aaa61089b644a9f4ca5f7929ce4f0d8885f"
+  integrity sha512-YbKsbpacI1OIvTGviUwuAAu7HPb/BeCxlo2AW6kyvRbNglocVxxcqvHW8Oe31r2oq98spEt7TPLMDuNyNNM5AA==
 
 "@sideway/address@^4.1.3":
   version "4.1.4"


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors
uikit-tools 배포후 버전 변경하여 한번더 커밋할 예정입니다.

[CLNP-3585](https://sendbird.atlassian.net/browse/CLNP-3585)

## Description Of Changes

Deprecated enableReactionsSupergroup in SendbirdUIKitContainer

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-3585]: https://sendbird.atlassian.net/browse/CLNP-3585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ