### PR TITLE
[CLNP-5361] fix: await token apis

### DIFF
--- a/packages/uikit-react-native/src/hooks/usePushTokenRegistration.ts
+++ b/packages/uikit-react-native/src/hooks/usePushTokenRegistration.ts
@@ -38,24 +38,27 @@ const usePushTokenRegistration = () => {
       }
     }
 
-    // Register device token
+    // Register token refresh listener
+    refreshListener.current = notificationService.onTokenRefresh(registerToken);
+
+    // Register token
     const token = await getToken();
     if (token) {
       Logger.log('[usePushTokenRegistration]', 'registered token:', token);
-      registerToken(token);
+      await registerToken(token);
     }
-
-    // Remove listener
-    refreshListener.current = notificationService.onTokenRefresh(registerToken);
   });
 
   const unregisterPushTokenForCurrentUser = useFreshCallback(async () => {
+    // Unregister token refresh listener
+    refreshListener.current?.();
+
+    // Unregister token
     const token = await getToken();
     if (token) {
-      unregisterToken(token);
+      await unregisterToken(token);
       Logger.log('[usePushTokenRegistration]', 'unregistered token:', token);
     }
-    refreshListener.current?.();
   });
 
   return { registerPushTokenForCurrentUser, unregisterPushTokenForCurrentUser };


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[CLNP-5361]

## Description Of Changes

If the API call is not awaited, the token deregistration API call may fail at the time of disconnection

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-5361]: https://sendbird.atlassian.net/browse/CLNP-5361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ