### PR TITLE
fix: remove default onOpenFileURL handler

### DIFF
--- a/packages/uikit-react-native/src/components/ChannelMessageList/index.tsx
+++ b/packages/uikit-react-native/src/components/ChannelMessageList/index.tsx
@@ -37,6 +37,7 @@ import {
   useSendbirdChat,
   useUserProfile,
 } from '../../hooks/useContext';
+import SBUUtils from '../../libs/SBUUtils';
 import ChatFlatList from '../ChatFlatList';
 import { ReactionAddons } from '../ReactionAddons';
 
@@ -271,8 +272,11 @@ const useCreateMessagePressActions = <T extends SendbirdGroupChannel | SendbirdO
       const fileType = getFileType(message.type || getFileExtension(message.name));
       if (['image', 'video', 'audio'].includes(fileType)) {
         onPressMediaMessage?.(message, () => onDeleteMessage(message), getAvailableUriFromFileMessage(message));
+        handlers.onOpenFileURL?.(message.url);
+      } else {
+        const openFile = handlers.onOpenFileURL ?? SBUUtils.openURL;
+        openFile(message.url);
       }
-      handlers.onOpenFileURL(message.url);
     }
   };
 

--- a/packages/uikit-react-native/src/components/ChannelThreadMessageList/index.tsx
+++ b/packages/uikit-react-native/src/components/ChannelThreadMessageList/index.tsx
@@ -37,6 +37,7 @@ import {
   useSendbirdChat,
   useUserProfile,
 } from '../../hooks/useContext';
+import SBUUtils from '../../libs/SBUUtils';
 import { ReactionAddons } from '../ReactionAddons';
 import ThreadChatFlatList from '../ThreadChatFlatList';
 
@@ -249,8 +250,11 @@ const useCreateMessagePressActions = <T extends SendbirdGroupChannel | SendbirdO
       const fileType = getFileType(message.type || getFileExtension(message.name));
       if (['image', 'video', 'audio'].includes(fileType)) {
         onPressMediaMessage?.(message, () => onDeleteMessage(message), getAvailableUriFromFileMessage(message));
+        handlers.onOpenFileURL?.(message.url);
+      } else {
+        const openFile = handlers.onOpenFileURL ?? SBUUtils.openURL;
+        openFile(message.url);
       }
-      handlers.onOpenFileURL(message.url);
     }
   };
 

--- a/packages/uikit-react-native/src/containers/SendbirdUIKitContainer.tsx
+++ b/packages/uikit-react-native/src/containers/SendbirdUIKitContainer.tsx
@@ -219,7 +219,6 @@ const SendbirdUIKitContainer = (props: SendbirdUIKitContainerProps) => {
 
   const sbuHandlers: SBUHandlers = {
     onOpenURL: SBUUtils.openURL,
-    onOpenFileURL: SBUUtils.openURL,
     ...handlers,
   };
 

--- a/packages/uikit-react-native/src/contexts/SBUHandlersCtx.tsx
+++ b/packages/uikit-react-native/src/contexts/SBUHandlersCtx.tsx
@@ -14,7 +14,7 @@ export interface SBUHandlers {
    * Note that this function is also called redundantly
    * when `onPressMediaMessage` handler is triggered by clicking on media messages containing images, videos, or audio.
    */
-  onOpenFileURL: (url: string) => void;
+  onOpenFileURL?: (url: string) => void;
 }
 
 type Props = React.PropsWithChildren<SBUHandlers>;

--- a/packages/uikit-react-native/src/domain/groupChannelThread/component/GroupChannelThreadParentMessageInfo.tsx
+++ b/packages/uikit-react-native/src/domain/groupChannelThread/component/GroupChannelThreadParentMessageInfo.tsx
@@ -31,6 +31,7 @@ import ThreadParentMessageRenderer, {
   ThreadParentMessageRendererProps,
 } from '../../../components/ThreadParentMessageRenderer';
 import { useLocalization, usePlatformService, useSBUHandlers, useSendbirdChat } from '../../../hooks/useContext';
+import SBUUtils from '../../../libs/SBUUtils';
 import { GroupChannelThreadContexts } from '../module/moduleContext';
 import type { GroupChannelThreadProps } from '../types';
 import { ReactionAddons } from './../../../components/ReactionAddons';
@@ -224,9 +225,12 @@ const useCreateMessagePressActions = ({
     if (message.isFileMessage()) {
       const fileType = getFileType(message.type || getFileExtension(message.name));
       if (['image', 'video', 'audio'].includes(fileType)) {
-        onPressMediaMessage?.(message, () => onDeleteMessage?.(message), getAvailableUriFromFileMessage(message));
+        onPressMediaMessage?.(message, () => onDeleteMessage(message), getAvailableUriFromFileMessage(message));
+        handlers.onOpenFileURL?.(message.url);
+      } else {
+        const openFile = handlers.onOpenFileURL ?? SBUUtils.openURL;
+        openFile(message.url);
       }
-      handlers.onOpenFileURL(message.url);
     }
   };
 
@@ -239,7 +243,7 @@ const useCreateMessagePressActions = ({
           text: STRINGS.LABELS.CHANNEL_MESSAGE_DELETE_CONFIRM_OK,
           style: 'destructive',
           onPress: () => {
-            onDeleteMessage?.(message).catch(onDeleteFailure);
+            onDeleteMessage(message).catch(onDeleteFailure);
           },
         },
       ],


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[TICKET_ID]

## Description Of Changes

Since `onOpenFileURL` is called redundantly with `onPressMediaMessage`, to maintain backward compatibility, the default `onOpenFileURL` should perform no action.

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test
