### PR TITLE
Remove Promise.allSettled to support Promise packages below version 8.

### DIFF
--- a/packages/uikit-react-native/src/contexts/PlatformServiceCtx.tsx
+++ b/packages/uikit-react-native/src/contexts/PlatformServiceCtx.tsx
@@ -31,7 +31,8 @@ export const PlatformServiceProvider = ({ children, voiceMessageConfig, ...servi
 
   useAppState('change', (state) => {
     if (state !== 'active') {
-      Promise.allSettled([services.playerService.reset(), services.recorderService.reset()]);
+      services.playerService.reset();
+      services.recorderService.reset();
     }
   });
 


### PR DESCRIPTION
While recent versions of React Native include `promise@^8` as a dependency, some projects are still using version 7. For example, tools like `graphql-codegen` rely on older versions.

Since `Promise.allSettled` doesn't provide additional value in this case, removing it will ensure compatibility with projects using older Promise packages.

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [X] Improvement (refactor code)
- [ ] Test
