### PR TITLE
[CLNP-5553] fix: ensure image visibility in file viewer on new architecture

### DIFF
--- a/packages/uikit-react-native/src/components/FileViewer/FileViewerContent.tsx
+++ b/packages/uikit-react-native/src/components/FileViewer/FileViewerContent.tsx
@@ -131,7 +131,7 @@ const ZoomableImageView = ({
 
 const styles = createStyleSheet({
   container: {
-    zIndex: -1,
+    zIndex: 0,
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',

--- a/packages/uikit-react-native/src/components/FileViewer/FileViewerFooter.tsx
+++ b/packages/uikit-react-native/src/components/FileViewer/FileViewerFooter.tsx
@@ -48,6 +48,7 @@ const FileViewerFooter = ({ bottomInset, deleteShown, onPressDelete, onPressDown
 
 const styles = createStyleSheet({
   container: {
+    zIndex: 1,
     position: 'absolute',
     left: 0,
     right: 0,

--- a/packages/uikit-react-native/src/components/FileViewer/FileViewerHeader.tsx
+++ b/packages/uikit-react-native/src/components/FileViewer/FileViewerHeader.tsx
@@ -58,6 +58,7 @@ const FileViewerHeader = ({ headerShown = true, topInset, onClose, subtitle, tit
 
 const styles = createStyleSheet({
   container: {
+    zIndex: 1,
     top: 0,
     left: 0,
     right: 0,


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[CLNP-5553]

## Description Of Changes

<img width=300 src=https://github.com/user-attachments/assets/ba1d395a-b888-4a77-a1a3-ef56cd8bdb40 />

Due to the z-index, this problem occurs only in the New architecture.

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-5553]: https://sendbird.atlassian.net/browse/CLNP-5553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ