### PR TITLE
fix: revert android camera permission

### DIFF
--- a/packages/uikit-react-native/README.md
+++ b/packages/uikit-react-native/README.md
@@ -79,11 +79,12 @@ Add the following permissions to your `android/app/src/main/AndroidManifest.xml`
     <!-- Permissions for voice message -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
-    <!-- Permissions for image attachments -->
+    <!-- Permissions for attachments -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Permissions for notifications (Android 13) -->
+    <!-- Permissions for notifications (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 </manifest>

--- a/packages/uikit-react-native/src/platform/createFileService.native.ts
+++ b/packages/uikit-react-native/src/platform/createFileService.native.ts
@@ -59,7 +59,7 @@ const createNativeFileService = ({
 }): FileServiceInterface => {
   const cameraPermissions: Permission[] = Platform.select({
     ios: [permissionModule.PERMISSIONS.IOS.CAMERA, permissionModule.PERMISSIONS.IOS.MICROPHONE],
-    android: [],
+    android: [permissionModule.PERMISSIONS.ANDROID.CAMERA],
     default: [],
   });
   const mediaLibraryPermissions: Permission[] = Platform.select({

--- a/sample/android/app/src/main/AndroidManifest.xml
+++ b/sample/android/app/src/main/AndroidManifest.xml
@@ -8,11 +8,12 @@
     <!-- Permissions for voice message -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
-    <!-- Permissions for image attachments -->
+    <!-- Permissions for attachments -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Permissions for notifications (Android 13) -->
+    <!-- Permissions for notifications (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[TICKET_ID]

## Description Of Changes

In the image picker library, camera permission is not a mandatory requirement. However, if camera permission is declared in the AndroidManifest.xml, it becomes mandatory to have this permission to call the launchCamera method.

In UIKit, it’s not possible to know if permissions are declared in the customer's app's AndroidManifest.xml, so it enforces the addition and requests the necessary permissions.

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test
