### PR TITLE
[CLNP-6724] fix: allow string values for borderRadius in StyleSheet

### DIFF
--- a/packages/uikit-react-native-foundation/src/styles/createStyleSheet.ts
+++ b/packages/uikit-react-native-foundation/src/styles/createStyleSheet.ts
@@ -21,7 +21,7 @@ const DEFAULT_SCALE_FACTOR_WITH_NUMERIC_VALUE = (
 const preProcessor: Partial<StylePreprocessor> = {
   'fontSize': DEFAULT_SCALE_FACTOR,
   'lineHeight': DEFAULT_SCALE_FACTOR,
-  //@ts-ignore
+  //@ts-ignore : Ensure compatibility with all supported React Native versions
   'borderRadius': DEFAULT_SCALE_FACTOR_WITH_NUMERIC_VALUE,
   'minWidth': SCALE_FACTOR_WITH_DIMENSION_VALUE,
   'maxWidth': SCALE_FACTOR_WITH_DIMENSION_VALUE,

--- a/packages/uikit-react-native-foundation/src/styles/createStyleSheet.ts
+++ b/packages/uikit-react-native-foundation/src/styles/createStyleSheet.ts
@@ -13,14 +13,15 @@ const SCALE_FACTOR_WITH_DIMENSION_VALUE = (
 };
 
 const DEFAULT_SCALE_FACTOR_WITH_NUMERIC_VALUE = (
-  val: NonNullable<AnimatableNumericValue | undefined>,
-): NonNullable<AnimatableNumericValue | undefined> => {
+  val: NonNullable<AnimatableNumericValue | string | undefined>,
+): NonNullable<AnimatableNumericValue | string | undefined> => {
   return typeof val === 'number' ? DEFAULT_SCALE_FACTOR(val) : val;
 };
 
 const preProcessor: Partial<StylePreprocessor> = {
   'fontSize': DEFAULT_SCALE_FACTOR,
   'lineHeight': DEFAULT_SCALE_FACTOR,
+  //@ts-ignore
   'borderRadius': DEFAULT_SCALE_FACTOR_WITH_NUMERIC_VALUE,
   'minWidth': SCALE_FACTOR_WITH_DIMENSION_VALUE,
   'maxWidth': SCALE_FACTOR_WITH_DIMENSION_VALUE,


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[[CLNP-6724]](https://sendbird.atlassian.net/browse/CLNP-6724)

## Description Of Changes

The borderRadius type in StyleSheet [was updated to support string values in React Native 0.75](https://github.com/facebook/react-native/commit/9c4ee6df087f9bc3024d893f1d87d54646661512).
To reflect this change, the parameter and return types were updated from
NonNullable<AnimatableNumericValue | undefined> to
NonNullable<AnimatableNumericValue | string | undefined>.

Additionally, // @ts-ignore was added to ensure compatibility with all supported React Native versions.

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-6724]: https://sendbird.atlassian.net/browse/CLNP-6724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ