### PR TITLE
[CLNP-7474] feat: supprot-for-text-input-props

### DIFF
--- a/packages/uikit-react-native/src/components/ChannelInput/EditInput.tsx
+++ b/packages/uikit-react-native/src/components/ChannelInput/EditInput.tsx
@@ -31,6 +31,7 @@ const EditInput = forwardRef<RNTextInput, EditInputProps>(function EditInput(
     autoFocus,
     mentionedUsers,
     inputDisabled,
+    partialTextInputProps,
   },
   ref,
 ) {
@@ -70,6 +71,7 @@ const EditInput = forwardRef<RNTextInput, EditInputProps>(function EditInput(
     <View style={styles.editInputContainer}>
       <View style={styles.inputWrapper}>
         <TextInput
+          {...partialTextInputProps}
           ref={ref}
           multiline
           disableFullscreenUI

--- a/packages/uikit-react-native/src/components/ChannelInput/SendInput.tsx
+++ b/packages/uikit-react-native/src/components/ChannelInput/SendInput.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import {
   NativeSyntheticEvent,
+  Platform,
   TextInput as RNTextInput,
   TextInputSelectionChangeEventData,
   TouchableOpacity,
@@ -117,7 +118,19 @@ const SendInput = forwardRef<RNTextInput, SendInputProps>(function SendInput(
       ...messageReplyParams,
     }).catch(onFailureToSend);
 
-    onChangeText('');
+    // On iOS with autoCorrect enabled, calling onChangeText('') immediately after sending
+    // can be ignored due to the keyboard's autocorrect not being committed yet.
+    // Delay the clear call slightly to allow the autocorrected text to be applied first.
+    if (Platform.OS === 'ios') {
+      const textInputRef = ref as React.MutableRefObject<RNTextInput | undefined>;
+      if (textInputRef.current) {
+        setTimeout(() => {
+          onChangeText('');
+        }, 10);
+      }
+    } else {
+      onChangeText('');
+    }
     setMessageToReply?.();
   };
 

--- a/packages/uikit-react-native/src/components/ChannelInput/SendInput.tsx
+++ b/packages/uikit-react-native/src/components/ChannelInput/SendInput.tsx
@@ -54,6 +54,7 @@ const SendInput = forwardRef<RNTextInput, SendInputProps>(function SendInput(
     messageToReply,
     setMessageToReply,
     messageForThread,
+    partialTextInputProps,
   },
   ref,
 ) {
@@ -186,6 +187,7 @@ const SendInput = forwardRef<RNTextInput, SendInputProps>(function SendInput(
       <View style={styles.sendInputContainer}>
         {AttachmentsButton && <AttachmentsButton onPress={() => openSheet({ sheetItems })} disabled={inputDisabled} />}
         <TextInput
+          {...partialTextInputProps}
           ref={ref}
           multiline
           disableFullscreenUI

--- a/packages/uikit-react-native/src/components/ChannelInput/index.tsx
+++ b/packages/uikit-react-native/src/components/ChannelInput/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { KeyboardAvoidingView, Platform, StyleProp, StyleSheet, TextInput, TextStyle, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, StyleProp, StyleSheet, TextInput, TextInputProps, TextStyle, View } from 'react-native';
 
 import { createStyleSheet, useUIKitTheme } from '@sendbird/uikit-react-native-foundation';
 import {
@@ -79,6 +79,9 @@ export type ChannelInputProps = {
   AttachmentsButton?: (props: AttachmentsButtonProps) => React.ReactNode | null;
   MessageToReplyPreview?: (props: MessageToReplyPreviewProps) => React.ReactNode | null;
   VoiceMessageInput?: (props: VoiceMessageInputProps) => React.ReactNode | null;
+
+  // TextInput props - only safe properties that don't interfere with UIKit functionality
+  partialTextInputProps?: Partial<Pick<TextInputProps, 'autoCorrect'>>;
 };
 
 const AUTO_FOCUS = Platform.select({ ios: false, android: true, default: false });

--- a/packages/uikit-react-native/src/components/ChannelInput/index.tsx
+++ b/packages/uikit-react-native/src/components/ChannelInput/index.tsx
@@ -1,5 +1,14 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { KeyboardAvoidingView, Platform, StyleProp, StyleSheet, TextInput, TextInputProps, TextStyle, View } from 'react-native';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  StyleProp,
+  StyleSheet,
+  TextInput,
+  TextInputProps,
+  TextStyle,
+  View,
+} from 'react-native';
 
 import { createStyleSheet, useUIKitTheme } from '@sendbird/uikit-react-native-foundation';
 import {

--- a/packages/uikit-react-native/src/domain/groupChannel/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannel/types.ts
@@ -53,6 +53,8 @@ export interface GroupChannelProps {
 
     searchItem?: GroupChannelProps['MessageList']['searchItem'];
 
+    partialTextInputProps?: GroupChannelProps['Input']['partialTextInputProps'];
+
     /**
      * @description You can specify the query parameters for the message list.
      * @example

--- a/packages/uikit-react-native/src/domain/groupChannel/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannel/types.ts
@@ -111,7 +111,8 @@ export interface GroupChannelProps {
     | 'onPressUpdateUserMessage'
     | 'onPressUpdateFileMessage'
     | 'SuggestedMentionList'
-    | 'AttachmentsButton',
+    | 'AttachmentsButton'
+    | 'partialTextInputProps',
     'inputDisabled'
   >;
 

--- a/packages/uikit-react-native/src/fragments/createGroupChannelFragment.tsx
+++ b/packages/uikit-react-native/src/fragments/createGroupChannelFragment.tsx
@@ -70,6 +70,7 @@ const createGroupChannelFragment = (initModule?: Partial<GroupChannelModule>): G
     flatListComponent,
     flatListProps,
     messageListQueryParams,
+    partialTextInputProps,
     collectionCreator,
   }) => {
     const { playerService, recorderService } = usePlatformService();
@@ -341,6 +342,7 @@ const createGroupChannelFragment = (initModule?: Partial<GroupChannelModule>): G
             onPressSendFileMessage={onPressSendFileMessage}
             onPressUpdateUserMessage={onPressUpdateUserMessage}
             onPressUpdateFileMessage={onPressUpdateFileMessage}
+            partialTextInputProps={partialTextInputProps}
           />
         </StatusComposition>
       </GroupChannelModule.Provider>


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[[CLNP-7474]](https://sendbird.atlassian.net/browse/CLNP-7474)

## Description Of Changes

GroupChannelInput 에서 autoCorrect기능을 on/off 할수 있도록 추가하였습니다.
autoCorrect 가 true 일때 iOS 에서 메세지 전송이후, 텍스트가 남아있는 현상 수정하였습니다.

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [x] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-7474]: https://sendbird.atlassian.net/browse/CLNP-7474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ