### PR TITLE
[CLNP-7468] fix: resolve search item scroll issue

### DIFF
--- a/packages/uikit-react-native/src/domain/groupChannel/types.ts
+++ b/packages/uikit-react-native/src/domain/groupChannel/types.ts
@@ -183,6 +183,16 @@ export interface GroupChannelContextsType {
       timeout?: number;
       viewPosition?: number;
     }) => void;
+    /**
+     * Call the FlatList function asynchronously to scroll to a message by messageId lazily.
+     * to avoid scrolling before data rendering has been committed.
+     * */
+    lazyScrollToMessageId: (params?: {
+      messageId?: number;
+      animated?: boolean;
+      timeout?: number;
+      viewPosition?: number;
+    }) => void;
 
     onPressReplyMessageInThread?: (parentMessage: SendbirdSendableMessage, startingPoint?: number) => void;
   }>;


### PR DESCRIPTION
## External Contributions

This project is not yet set up to accept pull requests from external contributors.

If you have a pull request that you believe should be accepted, please contact
the Developer Relations team <developer-advocates@sendbird.com> with details
and we'll evaluate if we can setup a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) to allow for the contribution.

## For Internal Contributors

[[CLNP-7468]](https://sendbird.atlassian.net/browse/CLNP-7468)

## Description Of Changes

search item 을 이용하여 groupChannel 진입시 lazyScrollToIndex를 이용하여 스크롤 처리를 하는데 다음과 같은 문제가 있습니다
1. lazyScrollToIndex 내부에서 timeout 딜레이를 주고 scrollToIndex 를 호출기전에 messages가 변경되면 index가 맞지 않은 문제
2. FlatList에서 내부 조건에 의해 onBottomReached를 호출하는데 collection의 cacheResult 와 apiResult 사이에 onBottomReached 로 인해 loadNext가 호출되면서 FlatList 내부 Data가 변경되며 scroll이 정상정으로 되지 않는 문제

해결방법
search item 을 이용해서 scroll 이 필요할때 lazyScrollToIndex 말고 messageId를 이용 해서 스크롤 순간에 index를 찾도록 수정
FlatList 내부 조건에 의해 onBottomReached 가 호출될때 hasNext 와 search item을 이용한 스크롤 중인지 체크해서 처리

## Types Of Changes

What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test


[CLNP-7468]: https://sendbird.atlassian.net/browse/CLNP-7468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ