### PR TITLE
fix: use premiumFeatureList for super group channel feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ env.ts
 version.ts
 
 *.app.dSYM.zip
+*.tsbuildinfo
 lerna-debug.log
 
 /docs

--- a/packages/uikit-chat-hooks/src/__tests__/common/useAppFeatures.test.ts
+++ b/packages/uikit-chat-hooks/src/__tests__/common/useAppFeatures.test.ts
@@ -8,12 +8,12 @@ describe('useAppFeatures', () => {
   it('should return app features', () => {
     const sdk = createMockSendbirdChat({
       appInfo: {
-        premiumFeatureList: [PremiumFeatures.delivery_receipt],
-        applicationAttributes: [
-          ApplicationAttributes.allow_broadcast_channel,
-          ApplicationAttributes.allow_super_group_channel,
-          ApplicationAttributes.reactions,
+        premiumFeatureList: [
+          PremiumFeatures.delivery_receipt,
+          PremiumFeatures.broadcast_channel,
+          PremiumFeatures.super_group_channel,
         ],
+        applicationAttributes: [ApplicationAttributes.reactions],
       },
     });
     const { result } = renderHook(() => useAppFeatures(sdk));

--- a/packages/uikit-chat-hooks/src/__tests__/common/useAppFeatures.test.ts
+++ b/packages/uikit-chat-hooks/src/__tests__/common/useAppFeatures.test.ts
@@ -8,12 +8,8 @@ describe('useAppFeatures', () => {
   it('should return app features', () => {
     const sdk = createMockSendbirdChat({
       appInfo: {
-        premiumFeatureList: [
-          PremiumFeatures.delivery_receipt,
-          PremiumFeatures.broadcast_channel,
-          PremiumFeatures.super_group_channel,
-        ],
-        applicationAttributes: [ApplicationAttributes.reactions],
+        premiumFeatureList: [PremiumFeatures.delivery_receipt, PremiumFeatures.super_group_channel],
+        applicationAttributes: [ApplicationAttributes.allow_broadcast_channel, ApplicationAttributes.reactions],
       },
     });
     const { result } = renderHook(() => useAppFeatures(sdk));

--- a/packages/uikit-chat-hooks/src/common/useAppFeatures.ts
+++ b/packages/uikit-chat-hooks/src/common/useAppFeatures.ts
@@ -4,8 +4,8 @@ export const useAppFeatures = (sdk: SendbirdChatSDK) => {
   const { premiumFeatureList = [], applicationAttributes = [], uploadSizeLimit } = sdk.appInfo ?? {};
   return {
     deliveryReceiptEnabled: premiumFeatureList.includes(PremiumFeatures.delivery_receipt),
-    broadcastChannelEnabled: applicationAttributes.includes(ApplicationAttributes.allow_broadcast_channel),
-    superGroupChannelEnabled: applicationAttributes.includes(ApplicationAttributes.allow_super_group_channel),
+    broadcastChannelEnabled: premiumFeatureList.includes(PremiumFeatures.broadcast_channel),
+    superGroupChannelEnabled: premiumFeatureList.includes(PremiumFeatures.super_group_channel),
     reactionEnabled: applicationAttributes.includes(ApplicationAttributes.reactions),
     uploadSizeLimit: uploadSizeLimit,
   };

--- a/packages/uikit-chat-hooks/src/common/useAppFeatures.ts
+++ b/packages/uikit-chat-hooks/src/common/useAppFeatures.ts
@@ -4,7 +4,7 @@ export const useAppFeatures = (sdk: SendbirdChatSDK) => {
   const { premiumFeatureList = [], applicationAttributes = [], uploadSizeLimit } = sdk.appInfo ?? {};
   return {
     deliveryReceiptEnabled: premiumFeatureList.includes(PremiumFeatures.delivery_receipt),
-    broadcastChannelEnabled: premiumFeatureList.includes(PremiumFeatures.broadcast_channel),
+    broadcastChannelEnabled: applicationAttributes.includes(ApplicationAttributes.allow_broadcast_channel),
     superGroupChannelEnabled: premiumFeatureList.includes(PremiumFeatures.super_group_channel),
     reactionEnabled: applicationAttributes.includes(ApplicationAttributes.reactions),
     uploadSizeLimit: uploadSizeLimit,

--- a/packages/uikit-utils/src/sendbird/attrs.ts
+++ b/packages/uikit-utils/src/sendbird/attrs.ts
@@ -36,6 +36,7 @@ export enum PremiumFeatures {
   auto_thumbnail = 'auto_thumbnail',
   image_moderation = 'image_moderation',
   super_group_channel = 'super_group_channel',
+  broadcast_channel = 'broadcast_channel',
   announcement = 'announcement',
   moderation_open = 'moderation_open',
   desk = 'desk',

--- a/packages/uikit-utils/src/sendbird/attrs.ts
+++ b/packages/uikit-utils/src/sendbird/attrs.ts
@@ -36,7 +36,6 @@ export enum PremiumFeatures {
   auto_thumbnail = 'auto_thumbnail',
   image_moderation = 'image_moderation',
   super_group_channel = 'super_group_channel',
-  broadcast_channel = 'broadcast_channel',
   announcement = 'announcement',
   moderation_open = 'moderation_open',
   desk = 'desk',


### PR DESCRIPTION
## Summary
- `useAppFeatures` hook에서 **super group channel** 기능 활성화 여부를 확인할 때 `applicationAttributes` 대신 `premiumFeatureList`를 사용하도록 수정
- 서버에서 `application_attributes > allow_super_group_channel` 플래그가 더 이상 사용되지 않고 `premium_feature_list`(`super_group_channel`)를 참조해야 함
- **broadcast channel은 기존대로 `applicationAttributes`(`allow_broadcast_channel`)를 그대로 참조** (서버 변경/배포 없음)

> 슬랙 쓰레드 최종 결론 (2026-05-20 ~ 05-21):
> - super group flag → `LOGI.premium_feature` 리스트 참조 ← **이번 변경 사항**
> - broadcast flag → `LOGI.application_attributes` 리스트 참조 ← **기존 그대로. 서버 배포도 없음**

## Changes
- `packages/uikit-chat-hooks/src/common/useAppFeatures.ts`: `superGroupChannelEnabled`를 `premiumFeatureList`에서 확인하도록 변경 (`broadcastChannelEnabled`는 `applicationAttributes` 유지)
- `packages/uikit-chat-hooks/src/__tests__/common/useAppFeatures.test.ts`: 테스트 업데이트 (super group은 premiumFeatureList, broadcast는 applicationAttributes)
- `PremiumFeatures` enum 변경 없음 (`super_group_channel`는 이미 존재)

## Test plan
- [x] 기존 테스트 통과 확인
- [ ] super group channel 생성 기능이 dashboard 설정에 따라 올바르게 활성화/비활성화되는지 확인
- [ ] broadcast channel 동작이 기존과 동일하게 유지되는지 확인

## Related
- Jira: CLNP-8532
- Slack thread: https://sendbird.slack.com/archives/C024J443JA2/p1779085615747149
