### PR TITLE
[codex] fix Expo clipboard async setter fallback

### DIFF
--- a/packages/uikit-react-native/src/__tests__/platform/createClipboardService.expo.test.ts
+++ b/packages/uikit-react-native/src/__tests__/platform/createClipboardService.expo.test.ts
@@ -1,0 +1,16 @@
+import createExpoClipboardService from '../../platform/createClipboardService.expo';
+
+describe('createExpoClipboardService', () => {
+  it('uses setStringAsync when Expo Clipboard does not provide setString', () => {
+    const clipboardModule = {
+      getStringAsync: jest.fn(),
+      setStringAsync: jest.fn(),
+    };
+
+    const clipboardService = createExpoClipboardService(clipboardModule as never);
+
+    clipboardService.setString('message');
+
+    expect(clipboardModule.setStringAsync).toHaveBeenCalledWith('message');
+  });
+});

--- a/packages/uikit-react-native/src/platform/createClipboardService.expo.ts
+++ b/packages/uikit-react-native/src/platform/createClipboardService.expo.ts
@@ -2,13 +2,24 @@ import type * as Clipboard from 'expo-clipboard';
 
 import type { ClipboardServiceInterface } from './types';
 
+type ExpoClipboardModule = typeof Clipboard & {
+  setString?: (text: string) => void;
+};
+
 const createExpoClipboardService = (clipboardModule: typeof Clipboard): ClipboardServiceInterface => {
+  const expoClipboardModule = clipboardModule as ExpoClipboardModule;
+
   return {
     getString(): Promise<string> {
       return clipboardModule.getStringAsync();
     },
     setString(text: string) {
-      return clipboardModule.setString(text);
+      if (typeof expoClipboardModule.setString === 'function') {
+        expoClipboardModule.setString(text);
+        return;
+      }
+
+      void clipboardModule.setStringAsync(text);
     },
   };
 };


### PR DESCRIPTION
## Summary

- Add an Expo Clipboard compatibility fallback for SDK 56, where `expo-clipboard` exposes `setStringAsync` but no longer provides `setString`.
- Keep the existing synchronous `setString` path for older Expo Clipboard versions.
- Add a regression test for the missing `setString` case.

## Root Cause

`createClipboardService.expo.ts` called `clipboardModule.setString(text)` directly. In Expo SDK 56 with `expo-clipboard@56.0.4`, that API is not available, so message copy actions do not write text to the clipboard.

## Validation

- `yarn jest packages/uikit-react-native/src/__tests__/platform/createClipboardService.expo.test.ts --runInBand`
- `yarn lerna run build --scope @sendbird/uikit-react-native --include-dependencies --stream`
- Expo 56 sample branch pushed separately: `version/expo-56`
- Expo 56 sample iOS simulator build/run verified with XcodeBuildMCP after applying the sample-only `expo-modules-jsi@56.0.10` Xcode 26 patch.

## Notes

The Expo 56 sample needs a separate `expo-modules-jsi` patch to build on Xcode 26 because the upstream package still contains `weak let runtime` Swift declarations. That patch is only for the sample app runtime and is not part of this UIKit fix.

## Ticket

- https://sendbird.atlassian.net/browse/CLNP-8682
