### PR TITLE
fix: support Expo 56 media library saves

### DIFF
--- a/packages/uikit-react-native/src/__tests__/platform/createFileService.expo.test.ts
+++ b/packages/uikit-react-native/src/__tests__/platform/createFileService.expo.test.ts
@@ -1,0 +1,89 @@
+import createExpoFileService from '../../platform/createFileService.expo';
+
+class ExpoFile {
+  static downloadFileAsync = jest.fn(async (_url: string, destination: ExpoFile, _options?: unknown) => {
+    return { uri: destination.uri };
+  });
+
+  constructor(public uri: string) {}
+
+  info() {
+    return { exists: true, isDirectory: false, uri: this.uri };
+  }
+}
+
+class ExpoDirectory {
+  constructor(public uri: string) {}
+}
+
+const createFileService = (mediaLibraryModule: Record<string, unknown>) => {
+  return createExpoFileService({
+    imagePickerModule: {} as never,
+    documentPickerModule: {} as never,
+    mediaLibraryModule: {
+      getPermissionsAsync: jest.fn(async () => ({ canAskAgain: true, granted: true, status: 'granted' })),
+      requestPermissionsAsync: jest.fn(),
+      ...mediaLibraryModule,
+    } as never,
+    fsModule: {
+      File: ExpoFile,
+      Directory: ExpoDirectory,
+      Paths: {
+        document: { uri: 'file:///documents' },
+        cache: { uri: 'file:///cache' },
+      },
+    } as never,
+  });
+};
+
+describe('createExpoFileService', () => {
+  beforeEach(() => {
+    ExpoFile.downloadFileAsync.mockClear();
+  });
+
+  it('uses the Expo MediaLibrary Asset API and idempotent downloads when saving media files', async () => {
+    const assetCreate = jest.fn(async () => ({}));
+    const saveToLibraryAsync = jest.fn(async () => {
+      throw new Error('legacy media library API should not be used');
+    });
+    const fileService = createFileService({
+      Asset: {
+        create: assetCreate,
+      },
+      saveToLibraryAsync,
+    });
+
+    await expect(
+      fileService.save({
+        fileUrl: 'https://example.com/photo.jpg',
+        fileName: 'photo.jpg',
+        fileType: 'image/jpeg',
+      }),
+    ).resolves.toBe('file:///documents/photo.jpg');
+
+    expect(ExpoFile.downloadFileAsync).toHaveBeenCalledWith(
+      'https://example.com/photo.jpg',
+      expect.objectContaining({ uri: 'file:///documents/photo.jpg' }),
+      expect.objectContaining({ idempotent: true }),
+    );
+    expect(assetCreate).toHaveBeenCalledWith('file:///documents/photo.jpg');
+    expect(saveToLibraryAsync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the legacy MediaLibrary save API when the Asset API is unavailable', async () => {
+    const saveToLibraryAsync = jest.fn(async () => undefined);
+    const fileService = createFileService({
+      saveToLibraryAsync,
+    });
+
+    await expect(
+      fileService.save({
+        fileUrl: 'https://example.com/legacy-photo.jpg',
+        fileName: 'legacy-photo.jpg',
+        fileType: 'image/jpeg',
+      }),
+    ).resolves.toBe('file:///documents/legacy-photo.jpg');
+
+    expect(saveToLibraryAsync).toHaveBeenCalledWith('file:///documents/legacy-photo.jpg');
+  });
+});

--- a/packages/uikit-react-native/src/platform/createFileService.expo.ts
+++ b/packages/uikit-react-native/src/platform/createFileService.expo.ts
@@ -18,6 +18,13 @@ import type {
   SaveOptions,
 } from './types';
 
+type ExpoMediaLibraryModule = typeof ExpoMediaLibrary & {
+  Asset?: {
+    create?: (localUri: string) => Promise<unknown>;
+  };
+  saveToLibraryAsync?: (localUri: string) => Promise<void>;
+};
+
 const createExpoFileService = ({
   imagePickerModule,
   documentPickerModule,
@@ -30,6 +37,7 @@ const createExpoFileService = ({
   fsModule: typeof ExpoFs;
 }): FileServiceInterface => {
   const preferredAssetRepresentationMode = imagePickerModule.UIImagePickerPreferredAssetRepresentationMode?.Compatible;
+  const expoMediaLibraryModule = mediaLibraryModule as ExpoMediaLibraryModule;
 
   class ExpoFileServiceInterface implements FileServiceInterface {
     async hasCameraPermission(): Promise<boolean> {
@@ -158,7 +166,13 @@ const createExpoFileService = ({
 
       const response = await expoBackwardUtils.fileSystem.downloadFile(fsModule, options.fileUrl, downloadPath);
       if (getFileType(options.fileType || '').match(/video|image/)) {
-        await mediaLibraryModule.saveToLibraryAsync(response.uri);
+        if (typeof expoMediaLibraryModule.Asset?.create === 'function') {
+          await expoMediaLibraryModule.Asset.create(response.uri);
+        } else if (typeof expoMediaLibraryModule.saveToLibraryAsync === 'function') {
+          await expoMediaLibraryModule.saveToLibraryAsync(response.uri);
+        } else {
+          throw new Error('Cannot save file to media library');
+        }
       }
       return response.uri;
     }

--- a/packages/uikit-react-native/src/utils/expoBackwardUtils.ts
+++ b/packages/uikit-react-native/src/utils/expoBackwardUtils.ts
@@ -153,7 +153,7 @@ const expoBackwardUtils = {
         return await fsModule.downloadAsync(url, localUri);
       } else {
         const destination = new fsModule.File(localUri);
-        const result = await fsModule.File.downloadFileAsync(url, destination as never);
+        const result = await fsModule.File.downloadFileAsync(url, destination as never, { idempotent: true });
         return { uri: result.uri };
       }
     },


### PR DESCRIPTION
## Summary
- Prefer Expo MediaLibrary `Asset.create` for media saves when available, matching Expo SDK 56's default API surface.
- Keep legacy `saveToLibraryAsync` fallback for older Expo versions.
- Pass `{ idempotent: true }` to Expo FileSystem `File.downloadFileAsync` so repeated saves to the same deterministic path do not fail with `DestinationAlreadyExists`.
- Add regression coverage for the Expo file service save path.

## Root cause
Expo SDK 56 keeps `saveToLibraryAsync` behind the legacy warning/throwing path on the default `expo-media-library` import. The first save can download the file, then fail while saving to the media library; later retries hit the same local destination path and fail before the media save step.

## Validation
- `yarn jest packages/uikit-react-native/src/__tests__/platform/createFileService.expo.test.ts --runInBand`
- `yarn jest packages/uikit-react-native/src/__tests__ --runInBand`
- `yarn workspace @sendbird/uikit-react-native build`
- `yarn prettier --check packages/uikit-react-native/src/platform/createFileService.expo.ts packages/uikit-react-native/src/utils/expoBackwardUtils.ts packages/uikit-react-native/src/__tests__/platform/createFileService.expo.test.ts`
- `yarn eslint packages/uikit-react-native/src/platform/createFileService.expo.ts packages/uikit-react-native/src/utils/expoBackwardUtils.ts packages/uikit-react-native/src/__tests__/platform/createFileService.expo.test.ts --ext ts,tsx -c ./.eslintrc.js`
- Expo 56 sample: linked local package with `yalc`, smoke-tested file service branch, then ran `npx expo run:ios --no-bundler`; app installed/launched on iPhone 16 simulator and Metro bundled `index.ts` successfully.

Refs SBISSUE-21791, [CLNP-8700](https://sendbird.atlassian.net/browse/CLNP-8700).

[CLNP-8700]: https://sendbird.atlassian.net/browse/CLNP-8700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ