### PR TITLE
release: v3.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+
+### Bug Fixes
+
+- revert broadcast channel flag to applicationAttributes ([2cd2bf1](https://github.com/sendbird/sendbird-uikit-react-native/commit/2cd2bf1688f5619b1f3e74b6af1bc2eb40bb8bdd))
+- support Expo 56 media library saves ([d265e4e](https://github.com/sendbird/sendbird-uikit-react-native/commit/d265e4e6075745832c659da6acd0c318330b5edf))
+- support Expo clipboard async setter ([b6cb8b5](https://github.com/sendbird/sendbird-uikit-react-native/commit/b6cb8b50901916ff99097d8bf605ce217b63ae96))
+- upgrade axios to ^1.16.0 (SECURE-3734) ([aaeb2fa](https://github.com/sendbird/sendbird-uikit-react-native/commit/aaeb2fa34905bb6b6c042ad465a0aaac5cb2694f))
+- upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216) ([e4fd5ea](https://github.com/sendbird/sendbird-uikit-react-native/commit/e4fd5eaa0a171b535037909261b3a571ec38a101))
+- upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438) ([576acaf](https://github.com/sendbird/sendbird-uikit-react-native/commit/576acaf1e1596f0c97d0a6d23ea052e06331415b))
+- use premiumFeatureList for super group and broadcast channel features ([bd81e37](https://github.com/sendbird/sendbird-uikit-react-native/commit/bd81e37050c293bd197c0efcee24b785e8e636ed))
+
 ## [3.12.6](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.5...v3.12.6) (2026-04-02)
 
 ### Features

--- a/CHANGELOG_DRAFT.md
+++ b/CHANGELOG_DRAFT.md
@@ -1,11 +1,11 @@
-## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+## [3.12.7]
 
 ### Bug Fixes
 
-- support Expo 56 media library saves ([d265e4e](https://github.com/sendbird/sendbird-uikit-react-native/commit/d265e4e6075745832c659da6acd0c318330b5edf))
-- support Expo clipboard async setter ([b6cb8b5](https://github.com/sendbird/sendbird-uikit-react-native/commit/b6cb8b50901916ff99097d8bf605ce217b63ae96))
-- use premiumFeatureList for super group and broadcast channel features ([bd81e37](https://github.com/sendbird/sendbird-uikit-react-native/commit/bd81e37050c293bd197c0efcee24b785e8e636ed))
-- revert broadcast channel flag to applicationAttributes ([2cd2bf1](https://github.com/sendbird/sendbird-uikit-react-native/commit/2cd2bf1688f5619b1f3e74b6af1bc2eb40bb8bdd))
-- upgrade axios to ^1.16.0 (SECURE-3734) ([aaeb2fa](https://github.com/sendbird/sendbird-uikit-react-native/commit/aaeb2fa34905bb6b6c042ad465a0aaac5cb2694f))
-- upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438) ([576acaf](https://github.com/sendbird/sendbird-uikit-react-native/commit/576acaf1e1596f0c97d0a6d23ea052e06331415b))
-- upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216) ([e4fd5ea](https://github.com/sendbird/sendbird-uikit-react-native/commit/e4fd5eaa0a171b535037909261b3a571ec38a101))
+- support Expo 56 media library saves
+- support Expo clipboard async setter
+- use premiumFeatureList for super group and broadcast channel features
+- revert broadcast channel flag to applicationAttributes
+- upgrade axios to ^1.16.0 (SECURE-3734)
+- upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438)
+- upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216)

--- a/CHANGELOG_DRAFT.md
+++ b/CHANGELOG_DRAFT.md
@@ -1,6 +1,19 @@
-## [3.12.6]
+## [3.12.7]
 
-### Features
+### Bug Fixes
 
-- feat: add customizable placeholder text for ChannelInput component
-- feat: export ChannelInputProps, EditInput, useMentionTextInput for external customization
+- fix: support Expo 56 media library saves
+- fix: support Expo clipboard async setter
+- fix: use premiumFeatureList for super group and broadcast channel features
+- fix: revert broadcast channel flag to applicationAttributes
+
+### Security
+
+- fix: upgrade axios to ^1.16.0 (SECURE-3734)
+- fix: upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438)
+- fix: upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216)
+
+### Chores
+
+- chore: merge docs workflows into single release-triggered pipeline
+- chore: add tsbuildinfo to gitignore

--- a/CHANGELOG_DRAFT.md
+++ b/CHANGELOG_DRAFT.md
@@ -12,8 +12,3 @@
 - fix: upgrade axios to ^1.16.0 (SECURE-3734)
 - fix: upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438)
 - fix: upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216)
-
-### Chores
-
-- chore: merge docs workflows into single release-triggered pipeline
-- chore: add tsbuildinfo to gitignore

--- a/CHANGELOG_DRAFT.md
+++ b/CHANGELOG_DRAFT.md
@@ -1,14 +1,11 @@
-## [3.12.7]
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 ### Bug Fixes
 
-- fix: support Expo 56 media library saves
-- fix: support Expo clipboard async setter
-- fix: use premiumFeatureList for super group and broadcast channel features
-- fix: revert broadcast channel flag to applicationAttributes
-
-### Security
-
-- fix: upgrade axios to ^1.16.0 (SECURE-3734)
-- fix: upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438)
-- fix: upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216)
+- support Expo 56 media library saves ([d265e4e](https://github.com/sendbird/sendbird-uikit-react-native/commit/d265e4e6075745832c659da6acd0c318330b5edf))
+- support Expo clipboard async setter ([b6cb8b5](https://github.com/sendbird/sendbird-uikit-react-native/commit/b6cb8b50901916ff99097d8bf605ce217b63ae96))
+- use premiumFeatureList for super group and broadcast channel features ([bd81e37](https://github.com/sendbird/sendbird-uikit-react-native/commit/bd81e37050c293bd197c0efcee24b785e8e636ed))
+- revert broadcast channel flag to applicationAttributes ([2cd2bf1](https://github.com/sendbird/sendbird-uikit-react-native/commit/2cd2bf1688f5619b1f3e74b6af1bc2eb40bb8bdd))
+- upgrade axios to ^1.16.0 (SECURE-3734) ([aaeb2fa](https://github.com/sendbird/sendbird-uikit-react-native/commit/aaeb2fa34905bb6b6c042ad465a0aaac5cb2694f))
+- upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438) ([576acaf](https://github.com/sendbird/sendbird-uikit-react-native/commit/576acaf1e1596f0c97d0a6d23ea052e06331415b))
+- upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216) ([e4fd5ea](https://github.com/sendbird/sendbird-uikit-react-native/commit/e4fd5eaa0a171b535037909261b3a571ec38a101))

--- a/docs-validation/CHANGELOG.md
+++ b/docs-validation/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+
+**Note:** Version bump only for package @sendbird/docs-validation
+
+
+
+
+
 ## [3.12.6](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.5...v3.12.6) (2026-04-02)
 
 **Note:** Version bump only for package @sendbird/docs-validation

--- a/docs-validation/package.json
+++ b/docs-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/docs-validation",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "private": true,
   "scripts": {
     "test": "tsc --project tsconfig.build.json",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*", "sample", "docs-validation"],
   "npmClient": "yarn",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "command": {
     "publish": {
       "conventionalCommits": true,

--- a/packages/uikit-chat-hooks/CHANGELOG.md
+++ b/packages/uikit-chat-hooks/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+
+### Bug Fixes
+
+- revert broadcast channel flag to applicationAttributes ([2cd2bf1](https://github.com/sendbird/sendbird-uikit-react-native/commit/2cd2bf1688f5619b1f3e74b6af1bc2eb40bb8bdd))
+- use premiumFeatureList for super group and broadcast channel features ([bd81e37](https://github.com/sendbird/sendbird-uikit-react-native/commit/bd81e37050c293bd197c0efcee24b785e8e636ed))
+
 ## [3.12.6](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.5...v3.12.6) (2026-04-02)
 
 **Note:** Version bump only for package @sendbird/uikit-chat-hooks

--- a/packages/uikit-chat-hooks/package.json
+++ b/packages/uikit-chat-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-chat-hooks",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "description": "A set of React hooks for integrating Sendbird chat functionality into your React app.",
   "keywords": [
     "sendbird",
@@ -54,10 +54,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@sendbird/uikit-utils": "3.12.6"
+    "@sendbird/uikit-utils": "3.12.7"
   },
   "devDependencies": {
-    "@sendbird/uikit-testing-tools": "3.12.6",
+    "@sendbird/uikit-testing-tools": "3.12.7",
     "@types/react": "*",
     "react": "19.1.1",
     "react-native-builder-bob": "^0.18.0",

--- a/packages/uikit-react-native-foundation/CHANGELOG.md
+++ b/packages/uikit-react-native-foundation/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+
+**Note:** Version bump only for package @sendbird/uikit-react-native-foundation
+
 ## [3.12.6](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.5...v3.12.6) (2026-04-02)
 
 **Note:** Version bump only for package @sendbird/uikit-react-native-foundation

--- a/packages/uikit-react-native-foundation/package.json
+++ b/packages/uikit-react-native-foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react-native-foundation",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "description": "A foundational UI kit for building chat-enabled React Native apps.",
   "keywords": [
     "sendbird",
@@ -57,7 +57,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sendbird/uikit-utils": "3.12.6"
+    "@sendbird/uikit-utils": "3.12.7"
   },
   "devDependencies": {
     "@types/react": "*",

--- a/packages/uikit-react-native/CHANGELOG.md
+++ b/packages/uikit-react-native/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+
+### Bug Fixes
+
+- support Expo 56 media library saves ([d265e4e](https://github.com/sendbird/sendbird-uikit-react-native/commit/d265e4e6075745832c659da6acd0c318330b5edf))
+- support Expo clipboard async setter ([b6cb8b5](https://github.com/sendbird/sendbird-uikit-react-native/commit/b6cb8b50901916ff99097d8bf605ce217b63ae96))
+
 ## [3.12.6](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.5...v3.12.6) (2026-04-02)
 
 ### Features

--- a/packages/uikit-react-native/package.json
+++ b/packages/uikit-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react-native",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "description": "Sendbird UIKit for React Native: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",
@@ -69,10 +69,10 @@
   },
   "dependencies": {
     "@openspacelabs/react-native-zoomable-view": "^2.3.0",
-    "@sendbird/uikit-chat-hooks": "3.12.6",
-    "@sendbird/uikit-react-native-foundation": "3.12.6",
+    "@sendbird/uikit-chat-hooks": "3.12.7",
+    "@sendbird/uikit-react-native-foundation": "3.12.7",
     "@sendbird/uikit-tools": "0.0.15",
-    "@sendbird/uikit-utils": "3.12.6"
+    "@sendbird/uikit-utils": "3.12.7"
   },
   "devDependencies": {
     "@bam.tech/react-native-image-resizer": "^3.0.11",

--- a/packages/uikit-testing-tools/CHANGELOG.md
+++ b/packages/uikit-testing-tools/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+
+**Note:** Version bump only for package @sendbird/uikit-testing-tools
+
 ## [3.12.6](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.5...v3.12.6) (2026-04-02)
 
 **Note:** Version bump only for package @sendbird/uikit-testing-tools

--- a/packages/uikit-testing-tools/package.json
+++ b/packages/uikit-testing-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-testing-tools",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "private": true,
   "description": "UIKit testing tools",
   "keywords": [
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@sendbird/chat": "^4.20.2",
-    "@sendbird/uikit-utils": "3.12.6",
+    "@sendbird/uikit-utils": "3.12.7",
     "@types/jest": "^29.4.0",
     "@types/react": "*",
     "@types/react-native": "*",

--- a/packages/uikit-utils/CHANGELOG.md
+++ b/packages/uikit-utils/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+
+**Note:** Version bump only for package @sendbird/uikit-utils
+
 ## [3.12.6](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.5...v3.12.6) (2026-04-02)
 
 **Note:** Version bump only for package @sendbird/uikit-utils

--- a/packages/uikit-utils/package.json
+++ b/packages/uikit-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-utils",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "description": "A collection of utility functions and constants for building chat UI components with Sendbird UIKit.",
   "keywords": [
     "sendbird",

--- a/sample/CHANGELOG.md
+++ b/sample/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
+
+**Note:** Version bump only for package @sendbird/uikit-sample-cli
+
 ## [3.12.6](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.5...v3.12.6) (2026-04-02)
 
 **Note:** Version bump only for package @sendbird/uikit-sample-cli

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-sample-cli",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## Release v3.12.7

## [3.12.7]

### Bug Fixes

- support Expo 56 media library saves
- support Expo clipboard async setter
- use premiumFeatureList for super group and broadcast channel features
- revert broadcast channel flag to applicationAttributes

### Security

- upgrade axios to ^1.16.0 (SECURE-3734)
- upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438)
- upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216)

---

### Checklist
- [ ] CHANGELOG_DRAFT.md is complete
- [ ] All tests pass
- [ ] Ready for \`publish-package\` workflow

### Next Steps
1. Add \`/bot create ticket\` comment to create a ticket
2. Run the \`publish-package\` workflow in GitHub Actions (version: 3.12.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)