### PR TITLE
fix: upgrade js-yaml to 3.15.0 / 4.3.0 (SECURE-4156)

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@types/react": "^19.1.1",
     "fast-xml-parser": "^4.5.6",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
-    "axios": "^1.16.0"
+    "axios": "^1.16.0",
+    "lerna/js-yaml": "^4.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8122,17 +8122,17 @@ js-convert-case@^4.2.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.1, js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@4.1.1, js-yaml@^4.1.0, js-yaml@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 
 js-yaml@^3.10.0, js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## For Internal Contributors

[SECURE-4156](https://sendbird.atlassian.net/browse/SECURE-4156)

## Description Of Changes

Fixes the High-severity SCA finding [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / [CVE-2026-59869](https://nvd.nist.gov/vuln/detail/CVE-2026-59869) on `js-yaml`.

`js-yaml` is vulnerable to uncontrolled resource consumption: a YAML document with a chain of mappings that each merge the previous one via the merge key (`<<`) makes the parser spend quadratic CPU time on input that only grows linearly. The patched releases cap merge keys at 10,000 per parse. Affected ranges are `>= 3.0.0 < 3.15.0` and `>= 4.0.0 < 4.3.0`, so both lines in the lockfile were in scope.

- `js-yaml@^3.10.0, ^3.13.1`: `3.14.2` → `3.15.0`
- `js-yaml@^4.1.0`: `4.1.1` → `4.3.0`
- Adds a scoped `resolutions` override, `"lerna/js-yaml": "^4.3.0"`, which removes the last vulnerable copy

### Why the override is scoped to `lerna` rather than repo-wide

Both majors are in use, and every consumer is build-time tooling:

| requested range | requested by |
| --- | --- |
| `^3.10.0` | `@yarnpkg/parsers` |
| `^3.13.1` | `@istanbuljs/load-nyc-config`, `front-matter` |
| `^4.1.0` | `eslint`, `@eslint/eslintrc`, `cosmiconfig`, `@expo/xcpretty` |
| `4.1.1` (exact) | `lerna` |

The v3 consumers still rely on the v3 API (`safeLoad`/`safeDump`), so the repo-wide `resolutions` style used for the axios and fast-xml-parser fixes would force them across the major boundary and break them. The caret ranges re-resolve on their own, so only `lerna`'s exact `4.1.1` pin needs redirecting — `lerna@9.0.7` is the latest release and still pins it exactly. Scoping the override to `lerna/js-yaml` leaves the v3 tree untouched, and a caret target lets future patch releases flow in automatically, matching the other overrides' style.

`@zkochan/js-yaml@0.0.7` is a separate package, not covered by this advisory, and is left as is.

## Types Of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance (ex) Prettier)
- [ ] Build configuration
- [ ] Improvement (refactor code)
- [ ] Test

## Test Plan

Verified in a clean worktree (fresh `node_modules`):

- [x] `yarn install --frozen-lockfile` succeeds with no lockfile drift, `postinstall`/`prepare` included
- [x] `yarn lint` passes (eslint + prettier)
- [x] `yarn test` passes — 34 suites, 190 tests
- [x] `yarn build` passes for all 5 projects (commonjs, module, typescript targets)
- [x] No vulnerable copy left: installed tree has `js-yaml@4.3.0` hoisted at the root (used by `lerna`/`eslint`) and `js-yaml@3.15.0` nested under `@yarnpkg/parsers`, `front-matter`, `@istanbuljs/load-nyc-config`
- [x] Patched `dependencies` are unchanged from the previous releases, so no new transitive packages are pulled in
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SECURE-4156]: https://sendbird.atlassian.net/browse/SECURE-4156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ