### PR TITLE
release: v3.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.8](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.7...v3.12.8) (2026-08-03)
+
+### Bug Fixes
+
+- apply modal window insets on every edge (SBISSUE-21901 review) ([3fc04cd](https://github.com/sendbird/sendbird-uikit-react-native/commit/3fc04cd3d3bd72babdfccd882f34e2eb3538c794))
+- detect the edge-to-edge window from the content frame (SBISSUE-21901 review) ([f0e4514](https://github.com/sendbird/sendbird-uikit-react-native/commit/f0e4514ec9436cb88a878d23e25873d27275e446))
+- keep modal content clear of the Android navigation bar (SBISSUE-21901) ([254e0c0](https://github.com/sendbird/sendbird-uikit-react-native/commit/254e0c0b2a853c4b1a57e27cdae4fb1e814a4cf6))
+- upgrade @sendbird/uikit-tools to 0.1.5 for thread message fixes ([5f9f1dd](https://github.com/sendbird/sendbird-uikit-react-native/commit/5f9f1dd0f410279fc81c6cf6d67bb05307a85d40))
+- upgrade js-yaml to 3.15.0 / 4.3.0 (SECURE-4156) ([9d70536](https://github.com/sendbird/sendbird-uikit-react-native/commit/9d70536bc20d8056801fd872c61f71da65ee093f))
+
 ## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 ### Bug Fixes

--- a/CHANGELOG_DRAFT.md
+++ b/CHANGELOG_DRAFT.md
@@ -1,11 +1,8 @@
-## [3.12.7]
+## [3.12.8]
 
 ### Bug Fixes
 
-- support Expo 56 media library saves
-- support Expo clipboard async setter
-- use premiumFeatureList for super group and broadcast channel features
-- revert broadcast channel flag to applicationAttributes
-- upgrade axios to ^1.16.0 (SECURE-3734)
-- upgrade vulnerable transitive deps (SECURE-2965, SECURE-3009, SECURE-3438)
-- upgrade nx transitive dep axios 1.12.0 → 1.15.0 (SECURE-3216)
+- keep modal content clear of the Android navigation bar
+- load older thread replies again after newer replies have been loaded
+- keep a just-sent thread reply in the list and remove a deleted one
+- upgrade js-yaml to 3.15.0 / 4.3.0

--- a/docs-validation/CHANGELOG.md
+++ b/docs-validation/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.8](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.7...v3.12.8) (2026-08-03)
+
+**Note:** Version bump only for package @sendbird/docs-validation
+
+
+
+
+
 ## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 **Note:** Version bump only for package @sendbird/docs-validation

--- a/docs-validation/package.json
+++ b/docs-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/docs-validation",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "private": true,
   "scripts": {
     "test": "tsc --project tsconfig.build.json",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*", "sample", "docs-validation"],
   "npmClient": "yarn",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "command": {
     "publish": {
       "conventionalCommits": true,

--- a/packages/uikit-chat-hooks/CHANGELOG.md
+++ b/packages/uikit-chat-hooks/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.8](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.7...v3.12.8) (2026-08-03)
+
+**Note:** Version bump only for package @sendbird/uikit-chat-hooks
+
 ## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 ### Bug Fixes

--- a/packages/uikit-chat-hooks/package.json
+++ b/packages/uikit-chat-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-chat-hooks",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "description": "A set of React hooks for integrating Sendbird chat functionality into your React app.",
   "keywords": [
     "sendbird",
@@ -54,10 +54,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@sendbird/uikit-utils": "3.12.7"
+    "@sendbird/uikit-utils": "3.12.8"
   },
   "devDependencies": {
-    "@sendbird/uikit-testing-tools": "3.12.7",
+    "@sendbird/uikit-testing-tools": "3.12.8",
     "@types/react": "*",
     "react": "19.1.1",
     "react-native-builder-bob": "^0.18.0",

--- a/packages/uikit-react-native-foundation/CHANGELOG.md
+++ b/packages/uikit-react-native-foundation/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.8](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.7...v3.12.8) (2026-08-03)
+
+### Bug Fixes
+
+- apply modal window insets on every edge (SBISSUE-21901 review) ([3fc04cd](https://github.com/sendbird/sendbird-uikit-react-native/commit/3fc04cd3d3bd72babdfccd882f34e2eb3538c794))
+- detect the edge-to-edge window from the content frame (SBISSUE-21901 review) ([f0e4514](https://github.com/sendbird/sendbird-uikit-react-native/commit/f0e4514ec9436cb88a878d23e25873d27275e446))
+- keep modal content clear of the Android navigation bar (SBISSUE-21901) ([254e0c0](https://github.com/sendbird/sendbird-uikit-react-native/commit/254e0c0b2a853c4b1a57e27cdae4fb1e814a4cf6))
+
 ## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 **Note:** Version bump only for package @sendbird/uikit-react-native-foundation

--- a/packages/uikit-react-native-foundation/package.json
+++ b/packages/uikit-react-native-foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react-native-foundation",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "description": "A foundational UI kit for building chat-enabled React Native apps.",
   "keywords": [
     "sendbird",
@@ -57,7 +57,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sendbird/uikit-utils": "3.12.7"
+    "@sendbird/uikit-utils": "3.12.8"
   },
   "devDependencies": {
     "@types/react": "*",

--- a/packages/uikit-react-native/CHANGELOG.md
+++ b/packages/uikit-react-native/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.8](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.7...v3.12.8) (2026-08-03)
+
+### Bug Fixes
+
+- apply modal window insets on every edge (SBISSUE-21901 review) ([3fc04cd](https://github.com/sendbird/sendbird-uikit-react-native/commit/3fc04cd3d3bd72babdfccd882f34e2eb3538c794))
+- keep modal content clear of the Android navigation bar (SBISSUE-21901) ([254e0c0](https://github.com/sendbird/sendbird-uikit-react-native/commit/254e0c0b2a853c4b1a57e27cdae4fb1e814a4cf6))
+- upgrade @sendbird/uikit-tools to 0.1.5 for thread message fixes ([5f9f1dd](https://github.com/sendbird/sendbird-uikit-react-native/commit/5f9f1dd0f410279fc81c6cf6d67bb05307a85d40))
+
 ## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 ### Bug Fixes

--- a/packages/uikit-react-native/package.json
+++ b/packages/uikit-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-react-native",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "description": "Sendbird UIKit for React Native: A feature-rich and customizable chat UI kit with messaging, channel management, and user authentication.",
   "keywords": [
     "sendbird",
@@ -69,10 +69,10 @@
   },
   "dependencies": {
     "@openspacelabs/react-native-zoomable-view": "^2.3.0",
-    "@sendbird/uikit-chat-hooks": "3.12.7",
-    "@sendbird/uikit-react-native-foundation": "3.12.7",
+    "@sendbird/uikit-chat-hooks": "3.12.8",
+    "@sendbird/uikit-react-native-foundation": "3.12.8",
     "@sendbird/uikit-tools": "0.1.5",
-    "@sendbird/uikit-utils": "3.12.7"
+    "@sendbird/uikit-utils": "3.12.8"
   },
   "devDependencies": {
     "@bam.tech/react-native-image-resizer": "^3.0.11",

--- a/packages/uikit-react-native/package.json
+++ b/packages/uikit-react-native/package.json
@@ -71,7 +71,7 @@
     "@openspacelabs/react-native-zoomable-view": "^2.3.0",
     "@sendbird/uikit-chat-hooks": "3.12.7",
     "@sendbird/uikit-react-native-foundation": "3.12.7",
-    "@sendbird/uikit-tools": "0.0.15",
+    "@sendbird/uikit-tools": "0.1.5",
     "@sendbird/uikit-utils": "3.12.7"
   },
   "devDependencies": {

--- a/packages/uikit-testing-tools/CHANGELOG.md
+++ b/packages/uikit-testing-tools/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.8](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.7...v3.12.8) (2026-08-03)
+
+**Note:** Version bump only for package @sendbird/uikit-testing-tools
+
 ## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 **Note:** Version bump only for package @sendbird/uikit-testing-tools

--- a/packages/uikit-testing-tools/package.json
+++ b/packages/uikit-testing-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-testing-tools",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "private": true,
   "description": "UIKit testing tools",
   "keywords": [
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@sendbird/chat": "^4.20.2",
-    "@sendbird/uikit-utils": "3.12.7",
+    "@sendbird/uikit-utils": "3.12.8",
     "@types/jest": "^29.4.0",
     "@types/react": "*",
     "@types/react-native": "*",

--- a/packages/uikit-utils/CHANGELOG.md
+++ b/packages/uikit-utils/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.8](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.7...v3.12.8) (2026-08-03)
+
+**Note:** Version bump only for package @sendbird/uikit-utils
+
 ## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 **Note:** Version bump only for package @sendbird/uikit-utils

--- a/packages/uikit-utils/package.json
+++ b/packages/uikit-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-utils",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "description": "A collection of utility functions and constants for building chat UI components with Sendbird UIKit.",
   "keywords": [
     "sendbird",

--- a/sample/CHANGELOG.md
+++ b/sample/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.12.8](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.7...v3.12.8) (2026-08-03)
+
+**Note:** Version bump only for package @sendbird/uikit-sample-cli
+
 ## [3.12.7](https://github.com/sendbird/sendbird-uikit-react-native/compare/v3.12.6...v3.12.7) (2026-07-06)
 
 **Note:** Version bump only for package @sendbird/uikit-sample-cli

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/uikit-sample-cli",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,10 +3281,10 @@
   resolved "https://registry.yarnpkg.com/@sendbird/react-native-create-thumbnail/-/react-native-create-thumbnail-1.0.2.tgz#e5e7de86ebe05d5b40d5ad26a21b631b5043a51e"
   integrity sha512-v13kjlRmSpjmGHwHzpk1eFGP5pOr+paxiOfvu01C7fvrmAAAreBL6mG3VW20wr8GxnVtbCLs1nJXBpabGnstog==
 
-"@sendbird/uikit-tools@0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@sendbird/uikit-tools/-/uikit-tools-0.0.15.tgz#86a1ac41fdf1624b984bd8f875d1091ac5842afa"
-  integrity sha512-VJukrtFwcqk5u4QYk0qva8ntJupvYCyNYjdNUWawjxYd9UbmODIld2TBkDBjiNtlVfK6UlzfKdvCVCJ30hC7pQ==
+"@sendbird/uikit-tools@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@sendbird/uikit-tools/-/uikit-tools-0.1.5.tgz#8e74eed665084374dc4dc5b449c05e01a64e9062"
+  integrity sha512-ZpiqUUL9hcCb/9uc27G9PKUmv4MnRiRekjGD+OKhGPZfyLGTk0UcJnGEB74Et3dQjWQR21rh2pjLjo6yvMvT0Q==
 
 "@sideway/address@^4.1.5":
   version "4.1.5"


### PR DESCRIPTION
## Release v3.12.8

## [3.12.8]

### Bug Fixes

- keep modal content clear of the Android navigation bar
- load older thread replies again after newer replies have been loaded
- keep a just-sent thread reply in the list and remove a deleted one
- upgrade js-yaml to 3.15.0 / 4.3.0

---

### Notes for the release announcement

- Apps that worked around the Android navigation bar overlap by adding their own bottom padding to a custom sheet header or footer may now see that padding doubled.
- `ModalSafeArea` is newly exported from `@sendbird/uikit-react-native-foundation`.
- `@sendbird/uikit-tools` moves from `0.0.15` to `0.1.5`. It is a pinned hard dependency, so the thread fixes cannot reach apps without this bump.

### Verification

- `yarn install --frozen-lockfile`, `yarn lint`, `yarn test` (34 suites / 190 tests) and `yarn build` (5 projects) pass on this branch.
- Metro bundling of the sample succeeds both with the default resolver and with package exports disabled. With exports disabled the new top-level `react-native` field resolves `@sendbird/uikit-tools` to its ESM build, which bundles cleanly.
- Checked on the iOS simulator (iPhone 16 Pro, sample on RN 0.82.1): channel list, channel, thread entry, sending and deleting a reply. In a seeded thread of 72 replies, entering mid-thread, paginating to the newest reply and then scrolling back reaches the parent message — the pagination that used to stay blocked after a `loadNext`.

### Checklist
- [ ] CHANGELOG_DRAFT.md is complete
- [ ] All tests pass
- [ ] Ready for `publish-package` workflow

### Next Steps
1. Add `/bot create ticket` comment to create a ticket
2. Run the `publish-package` workflow in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)